### PR TITLE
skip unnecessary autoconf step

### DIFF
--- a/doc/mainpage.dox
+++ b/doc/mainpage.dox
@@ -94,8 +94,7 @@ git repository.
 To build the library under GNU/Linux and run the tests, type the following:
 
 \code
-$ automake --add-missing
-$ autoreconf
+$ autoreconf -i
 $ ./configure
 $ make
 $ make check


### PR DESCRIPTION
`autoreconf -i` should automatically generate missing files.
This saves one step, and is more general than adding
`automake --add-missing` since it would handle `libtool`
in case you'll ever use that.

https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/autoreconf-Invocation.html
-i
Install the missing auxiliary files in the package. By default, files are copied; this can be changed with --symlink.
If deemed appropriate, this option triggers calls to ‘automake --add-missing’, ‘libtoolize’, ‘autopoint’, etc.