### PR TITLE
Crypto backends

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Rhys Weatherley <rhys.weatherley@gmail.com>
+Eli Fidler <efidler@topologyinc.com>

--- a/configure.ac
+++ b/configure.ac
@@ -63,4 +63,16 @@ examples/echo/echo-client/Makefile
 examples/echo/echo-keygen/Makefile
 examples/echo/echo-server/Makefile
 doc/Makefile])
+
+AC_ARG_WITH([libsodium],
+  [AS_HELP_STRING([--with-libsodium],
+    [use libsodium for crypto @<:@default=check@:>@])],
+  [],
+  [with_libsodium=check])
+AS_CASE(["$with_libsodium"],
+  [yes], [PKG_CHECK_MODULES([libsodium], [libsodium], [HAVE_LIBSODIUM=1])],
+  [no], [HAVE_LIBSODIUM=0],
+  [PKG_CHECK_MODULES([libsodium], [libsodium], [HAVE_LIBSODIUM=1], [HAVE_LIBSODIUM=0])])
+AM_CONDITIONAL([USE_LIBSODIUM], [test "$with_libsodium" != no -a "$HAVE_LIBSODIUM" -eq 1])
+
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -75,4 +75,15 @@ AS_CASE(["$with_libsodium"],
   [PKG_CHECK_MODULES([libsodium], [libsodium], [HAVE_LIBSODIUM=1], [HAVE_LIBSODIUM=0])])
 AM_CONDITIONAL([USE_LIBSODIUM], [test "$with_libsodium" != no -a "$HAVE_LIBSODIUM" -eq 1])
 
+AC_ARG_WITH([openssl],
+  [AS_HELP_STRING([--with-openssl],
+    [use openssl for crypto @<:@default=check@:>@])],
+  [],
+  [with_openssl=check])
+AS_CASE(["$with_openssl"],
+  [yes], [PKG_CHECK_MODULES([openssl], [openssl], [HAVE_OPENSSL=1])],
+  [no], [HAVE_OPENSSL=0],
+  [PKG_CHECK_MODULES([openssl], [openssl], [HAVE_OPENSSL=1], [HAVE_OPENSSL=0])])
+AM_CONDITIONAL([USE_OPENSSL], [test "$with_openssl" != no -a "$HAVE_OPENSSL" -eq 1])
+
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,7 @@
 
 AC_INIT([noise-c], [0.0.1])
 AM_INIT_AUTOMAKE
+AC_CONFIG_MACRO_DIR([m4])
 
 AC_PROG_CC
 AC_PROG_CC_STDC
@@ -36,6 +37,8 @@ AC_CHECK_LIB(ws2_32, [_head_lib32_libws2_32_a])
 AC_CHECK_LIB(ws2_32, [_head_lib64_libws2_32_a])
 
 AC_CHECK_FUNCS([poll])
+
+AX_PTHREAD
 
 AC_SUBST([WARNING_FLAGS],[-Wall])
 AC_SUBST([GOLDILOCKS_ARCH],[$with_ed448_arch])

--- a/doc/mainpage.dox
+++ b/doc/mainpage.dox
@@ -74,6 +74,7 @@ page on the Noise wiki.
 \li \ref signstate "SignState"
 \li \ref randstate "RandState"
 \li \ref keyloader "Key/certificate loading and saving"
+\li \ref utils "Utilities"
 
 \section other_info Other information
 
@@ -94,7 +95,8 @@ page on the Noise wiki.
     \ref cipherstate "CipherState", \ref hashstate "HashState",
     \ref dhstate "DHState", and \ref signstate "SignState" that use the
     reference cryptographic primitives.
-\li <tt>src/backend/xyz/</tt> - Recommended location for alternative backends.
+\li <tt>src/backend/openssl/</tt> - OpenSSL crypto backend
+\li <tt>src/backend/sodium/</tt> - libsodium crypto backend
 \li <tt>tools/protoc/</tt> - Source code for the Noise-C protobufs compiler.
 \li <tt>tools/keytool/</tt> - Command-line key and certificate management tool.
 \li <tt>tests/unit/</tt> - Unit tests to exercise the library's functionality.
@@ -128,8 +130,6 @@ In no particular order:
 \li Examples and overview documentation.
 \li Mechanism to encrypt static keypairs with a passphrase.
 \li Complete the standalone key generation utility for static keypairs.
-\li Port to other platforms (rand_os.c is a particular place that needs work).
-\li Back ends for other cryptography libraries: OpenSSL, libsodium, ...
 \li Compile-time subsetting of the library for applications that only
     need a subset of the algorithms, and for platforms with limited memory.
 

--- a/examples/echo/echo-client/Makefile.am
+++ b/examples/echo/echo-client/Makefile.am
@@ -9,3 +9,9 @@ AM_CPPFLAGS = -I$(top_srcdir)/include -I$(srcdir)/../echo-server
 AM_CFLAGS = @WARNING_FLAGS@
 
 LDADD = ../../../src/protocol/libnoiseprotocol.a
+
+if USE_LIBSODIUM
+AM_CPPFLAGS += -DUSE_LIBSODIUM=1
+AM_CFLAGS += $(libsodium_CFLAGS)
+LDADD += $(libsodium_LIBS)
+endif

--- a/examples/echo/echo-client/Makefile.am
+++ b/examples/echo/echo-client/Makefile.am
@@ -15,3 +15,9 @@ AM_CPPFLAGS += -DUSE_LIBSODIUM=1
 AM_CFLAGS += $(libsodium_CFLAGS)
 LDADD += $(libsodium_LIBS)
 endif
+
+if USE_OPENSSL
+AM_CPPFLAGS += -DUSE_OPENSSL=1
+AM_CFLAGS += $(openssl_CFLAGS)
+LDADD += $(openssl_LIBS)
+endif

--- a/examples/echo/echo-client/echo-client.c
+++ b/examples/echo/echo-client/echo-client.c
@@ -373,6 +373,11 @@ int main(int argc, char *argv[])
     if (!parse_options(argc, argv))
         return 1;
 
+    if (noise_init() != NOISE_ERROR_NONE) {
+        fprintf(stderr, "Noise initialization failed\n");
+        return 1;
+    }
+
     /* Check that the echo protocol supports the handshake protocol.
        One-way handshake patterns and XXfallback are not yet supported. */
     if (!echo_get_protocol_id(&id, protocol, post_quantum)) {

--- a/examples/echo/echo-keygen/Makefile.am
+++ b/examples/echo/echo-keygen/Makefile.am
@@ -7,3 +7,9 @@ AM_CPPFLAGS = -I$(top_srcdir)/include
 AM_CFLAGS = @WARNING_FLAGS@
 
 LDADD = ../../../src/protocol/libnoiseprotocol.a
+
+if USE_LIBSODIUM
+AM_CPPFLAGS += -DUSE_LIBSODIUM=1
+AM_CFLAGS += $(libsodium_CFLAGS)
+LDADD += $(libsodium_LIBS)
+endif

--- a/examples/echo/echo-keygen/Makefile.am
+++ b/examples/echo/echo-keygen/Makefile.am
@@ -13,3 +13,9 @@ AM_CPPFLAGS += -DUSE_LIBSODIUM=1
 AM_CFLAGS += $(libsodium_CFLAGS)
 LDADD += $(libsodium_LIBS)
 endif
+
+if USE_OPENSSL
+AM_CPPFLAGS += -DUSE_OPENSSL=1
+AM_CFLAGS += $(openssl_CFLAGS)
+LDADD += $(openssl_LIBS)
+endif

--- a/examples/echo/echo-keygen/echo-keygen.c
+++ b/examples/echo/echo-keygen/echo-keygen.c
@@ -55,6 +55,11 @@ int main(int argc, char *argv[])
     priv_key_file = argv[2];
     pub_key_file = argv[3];
 
+    if (noise_init() != NOISE_ERROR_NONE) {
+        fprintf(stderr, "Noise initialization failed\n");
+        return 1;
+    }
+
     /* Generate a keypair */
     err = noise_dhstate_new_by_name(&dh, key_type);
     if (err != NOISE_ERROR_NONE) {

--- a/examples/echo/echo-server/Makefile.am
+++ b/examples/echo/echo-server/Makefile.am
@@ -15,3 +15,9 @@ AM_CPPFLAGS += -DUSE_LIBSODIUM=1
 AM_CFLAGS += $(libsodium_CFLAGS)
 LDADD += $(libsodium_LIBS)
 endif
+
+if USE_OPENSSL
+AM_CPPFLAGS += -DUSE_OPENSSL=1
+AM_CFLAGS += $(openssl_CFLAGS)
+LDADD += $(openssl_LIBS)
+endif

--- a/examples/echo/echo-server/Makefile.am
+++ b/examples/echo/echo-server/Makefile.am
@@ -9,3 +9,9 @@ AM_CPPFLAGS = -I$(top_srcdir)/include
 AM_CFLAGS = @WARNING_FLAGS@
 
 LDADD = ../../../src/protocol/libnoiseprotocol.a
+
+if USE_LIBSODIUM
+AM_CPPFLAGS += -DUSE_LIBSODIUM=1
+AM_CFLAGS += $(libsodium_CFLAGS)
+LDADD += $(libsodium_LIBS)
+endif

--- a/examples/echo/echo-server/echo-server.c
+++ b/examples/echo/echo-server/echo-server.c
@@ -346,6 +346,11 @@ int main(int argc, char *argv[])
     if (!parse_options(argc, argv))
         return 1;
 
+    if (noise_init() != NOISE_ERROR_NONE) {
+        fprintf(stderr, "Noise initialization failed\n");
+        return 1;
+    }
+
     /* Change into the key directory and load all of the keys we'll need */
     if (chdir(key_dir) < 0) {
         perror(key_dir);

--- a/include/noise/protocol/util.h
+++ b/include/noise/protocol/util.h
@@ -30,6 +30,8 @@
 extern "C" {
 #endif
 
+int noise_init(void);
+
 #define noise_new(type) ((type *)noise_new_object(sizeof(type)))
 void *noise_new_object(size_t size);
 void noise_free(void *ptr, size_t size);

--- a/m4/ax_pthread.m4
+++ b/m4/ax_pthread.m4
@@ -1,0 +1,485 @@
+# ===========================================================================
+#        http://www.gnu.org/software/autoconf-archive/ax_pthread.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PTHREAD([ACTION-IF-FOUND[, ACTION-IF-NOT-FOUND]])
+#
+# DESCRIPTION
+#
+#   This macro figures out how to build C programs using POSIX threads. It
+#   sets the PTHREAD_LIBS output variable to the threads library and linker
+#   flags, and the PTHREAD_CFLAGS output variable to any special C compiler
+#   flags that are needed. (The user can also force certain compiler
+#   flags/libs to be tested by setting these environment variables.)
+#
+#   Also sets PTHREAD_CC to any special C compiler that is needed for
+#   multi-threaded programs (defaults to the value of CC otherwise). (This
+#   is necessary on AIX to use the special cc_r compiler alias.)
+#
+#   NOTE: You are assumed to not only compile your program with these flags,
+#   but also to link with them as well. For example, you might link with
+#   $PTHREAD_CC $CFLAGS $PTHREAD_CFLAGS $LDFLAGS ... $PTHREAD_LIBS $LIBS
+#
+#   If you are only building threaded programs, you may wish to use these
+#   variables in your default LIBS, CFLAGS, and CC:
+#
+#     LIBS="$PTHREAD_LIBS $LIBS"
+#     CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+#     CC="$PTHREAD_CC"
+#
+#   In addition, if the PTHREAD_CREATE_JOINABLE thread-attribute constant
+#   has a nonstandard name, this macro defines PTHREAD_CREATE_JOINABLE to
+#   that name (e.g. PTHREAD_CREATE_UNDETACHED on AIX).
+#
+#   Also HAVE_PTHREAD_PRIO_INHERIT is defined if pthread is found and the
+#   PTHREAD_PRIO_INHERIT symbol is defined when compiling with
+#   PTHREAD_CFLAGS.
+#
+#   ACTION-IF-FOUND is a list of shell commands to run if a threads library
+#   is found, and ACTION-IF-NOT-FOUND is a list of commands to run it if it
+#   is not found. If ACTION-IF-FOUND is not specified, the default action
+#   will define HAVE_PTHREAD.
+#
+#   Please let the authors know if this macro fails on any platform, or if
+#   you have any other suggestions or comments. This macro was based on work
+#   by SGJ on autoconf scripts for FFTW (http://www.fftw.org/) (with help
+#   from M. Frigo), as well as ac_pthread and hb_pthread macros posted by
+#   Alejandro Forero Cuervo to the autoconf macro repository. We are also
+#   grateful for the helpful feedback of numerous users.
+#
+#   Updated for Autoconf 2.68 by Daniel Richard G.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
+#   Copyright (c) 2011 Daniel Richard G. <skunk@iSKUNK.ORG>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 23
+
+AU_ALIAS([ACX_PTHREAD], [AX_PTHREAD])
+AC_DEFUN([AX_PTHREAD], [
+AC_REQUIRE([AC_CANONICAL_HOST])
+AC_REQUIRE([AC_PROG_CC])
+AC_REQUIRE([AC_PROG_SED])
+AC_LANG_PUSH([C])
+ax_pthread_ok=no
+
+# We used to check for pthread.h first, but this fails if pthread.h
+# requires special compiler flags (e.g. on Tru64 or Sequent).
+# It gets checked for in the link test anyway.
+
+# First of all, check if the user has set any of the PTHREAD_LIBS,
+# etcetera environment variables, and if threads linking works using
+# them:
+if test "x$PTHREAD_CFLAGS$PTHREAD_LIBS" != "x"; then
+        ax_pthread_save_CC="$CC"
+        ax_pthread_save_CFLAGS="$CFLAGS"
+        ax_pthread_save_LIBS="$LIBS"
+        AS_IF([test "x$PTHREAD_CC" != "x"], [CC="$PTHREAD_CC"])
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+        AC_MSG_CHECKING([for pthread_join using $CC $PTHREAD_CFLAGS $PTHREAD_LIBS])
+        AC_LINK_IFELSE([AC_LANG_CALL([], [pthread_join])], [ax_pthread_ok=yes])
+        AC_MSG_RESULT([$ax_pthread_ok])
+        if test "x$ax_pthread_ok" = "xno"; then
+                PTHREAD_LIBS=""
+                PTHREAD_CFLAGS=""
+        fi
+        CC="$ax_pthread_save_CC"
+        CFLAGS="$ax_pthread_save_CFLAGS"
+        LIBS="$ax_pthread_save_LIBS"
+fi
+
+# We must check for the threads library under a number of different
+# names; the ordering is very important because some systems
+# (e.g. DEC) have both -lpthread and -lpthreads, where one of the
+# libraries is broken (non-POSIX).
+
+# Create a list of thread flags to try.  Items starting with a "-" are
+# C compiler flags, and other items are library names, except for "none"
+# which indicates that we try without any flags at all, and "pthread-config"
+# which is a program returning the flags for the Pth emulation library.
+
+ax_pthread_flags="pthreads none -Kthread -pthread -pthreads -mthreads pthread --thread-safe -mt pthread-config"
+
+# The ordering *is* (sometimes) important.  Some notes on the
+# individual items follow:
+
+# pthreads: AIX (must check this before -lpthread)
+# none: in case threads are in libc; should be tried before -Kthread and
+#       other compiler flags to prevent continual compiler warnings
+# -Kthread: Sequent (threads in libc, but -Kthread needed for pthread.h)
+# -pthread: Linux/gcc (kernel threads), BSD/gcc (userland threads), Tru64
+#           (Note: HP C rejects this with "bad form for `-t' option")
+# -pthreads: Solaris/gcc (Note: HP C also rejects)
+# -mt: Sun Workshop C (may only link SunOS threads [-lthread], but it
+#      doesn't hurt to check since this sometimes defines pthreads and
+#      -D_REENTRANT too), HP C (must be checked before -lpthread, which
+#      is present but should not be used directly; and before -mthreads,
+#      because the compiler interprets this as "-mt" + "-hreads")
+# -mthreads: Mingw32/gcc, Lynx/gcc
+# pthread: Linux, etcetera
+# --thread-safe: KAI C++
+# pthread-config: use pthread-config program (for GNU Pth library)
+
+case $host_os in
+
+        freebsd*)
+
+        # -kthread: FreeBSD kernel threads (preferred to -pthread since SMP-able)
+        # lthread: LinuxThreads port on FreeBSD (also preferred to -pthread)
+
+        ax_pthread_flags="-kthread lthread $ax_pthread_flags"
+        ;;
+
+        hpux*)
+
+        # From the cc(1) man page: "[-mt] Sets various -D flags to enable
+        # multi-threading and also sets -lpthread."
+
+        ax_pthread_flags="-mt -pthread pthread $ax_pthread_flags"
+        ;;
+
+        openedition*)
+
+        # IBM z/OS requires a feature-test macro to be defined in order to
+        # enable POSIX threads at all, so give the user a hint if this is
+        # not set. (We don't define these ourselves, as they can affect
+        # other portions of the system API in unpredictable ways.)
+
+        AC_EGREP_CPP([AX_PTHREAD_ZOS_MISSING],
+            [
+#            if !defined(_OPEN_THREADS) && !defined(_UNIX03_THREADS)
+             AX_PTHREAD_ZOS_MISSING
+#            endif
+            ],
+            [AC_MSG_WARN([IBM z/OS requires -D_OPEN_THREADS or -D_UNIX03_THREADS to enable pthreads support.])])
+        ;;
+
+        solaris*)
+
+        # On Solaris (at least, for some versions), libc contains stubbed
+        # (non-functional) versions of the pthreads routines, so link-based
+        # tests will erroneously succeed. (N.B.: The stubs are missing
+        # pthread_cleanup_push, or rather a function called by this macro,
+        # so we could check for that, but who knows whether they'll stub
+        # that too in a future libc.)  So we'll check first for the
+        # standard Solaris way of linking pthreads (-mt -lpthread).
+
+        ax_pthread_flags="-mt,pthread pthread $ax_pthread_flags"
+        ;;
+esac
+
+# GCC generally uses -pthread, or -pthreads on some platforms (e.g. SPARC)
+
+AS_IF([test "x$GCC" = "xyes"],
+      [ax_pthread_flags="-pthread -pthreads $ax_pthread_flags"])
+
+# The presence of a feature test macro requesting re-entrant function
+# definitions is, on some systems, a strong hint that pthreads support is
+# correctly enabled
+
+case $host_os in
+        darwin* | hpux* | linux* | osf* | solaris*)
+        ax_pthread_check_macro="_REENTRANT"
+        ;;
+
+        aix*)
+        ax_pthread_check_macro="_THREAD_SAFE"
+        ;;
+
+        *)
+        ax_pthread_check_macro="--"
+        ;;
+esac
+AS_IF([test "x$ax_pthread_check_macro" = "x--"],
+      [ax_pthread_check_cond=0],
+      [ax_pthread_check_cond="!defined($ax_pthread_check_macro)"])
+
+# Are we compiling with Clang?
+
+AC_CACHE_CHECK([whether $CC is Clang],
+    [ax_cv_PTHREAD_CLANG],
+    [ax_cv_PTHREAD_CLANG=no
+     # Note that Autoconf sets GCC=yes for Clang as well as GCC
+     if test "x$GCC" = "xyes"; then
+        AC_EGREP_CPP([AX_PTHREAD_CC_IS_CLANG],
+            [/* Note: Clang 2.7 lacks __clang_[a-z]+__ */
+#            if defined(__clang__) && defined(__llvm__)
+             AX_PTHREAD_CC_IS_CLANG
+#            endif
+            ],
+            [ax_cv_PTHREAD_CLANG=yes])
+     fi
+    ])
+ax_pthread_clang="$ax_cv_PTHREAD_CLANG"
+
+ax_pthread_clang_warning=no
+
+# Clang needs special handling, because older versions handle the -pthread
+# option in a rather... idiosyncratic way
+
+if test "x$ax_pthread_clang" = "xyes"; then
+
+        # Clang takes -pthread; it has never supported any other flag
+
+        # (Note 1: This will need to be revisited if a system that Clang
+        # supports has POSIX threads in a separate library.  This tends not
+        # to be the way of modern systems, but it's conceivable.)
+
+        # (Note 2: On some systems, notably Darwin, -pthread is not needed
+        # to get POSIX threads support; the API is always present and
+        # active.  We could reasonably leave PTHREAD_CFLAGS empty.  But
+        # -pthread does define _REENTRANT, and while the Darwin headers
+        # ignore this macro, third-party headers might not.)
+
+        PTHREAD_CFLAGS="-pthread"
+        PTHREAD_LIBS=
+
+        ax_pthread_ok=yes
+
+        # However, older versions of Clang make a point of warning the user
+        # that, in an invocation where only linking and no compilation is
+        # taking place, the -pthread option has no effect ("argument unused
+        # during compilation").  They expect -pthread to be passed in only
+        # when source code is being compiled.
+        #
+        # Problem is, this is at odds with the way Automake and most other
+        # C build frameworks function, which is that the same flags used in
+        # compilation (CFLAGS) are also used in linking.  Many systems
+        # supported by AX_PTHREAD require exactly this for POSIX threads
+        # support, and in fact it is often not straightforward to specify a
+        # flag that is used only in the compilation phase and not in
+        # linking.  Such a scenario is extremely rare in practice.
+        #
+        # Even though use of the -pthread flag in linking would only print
+        # a warning, this can be a nuisance for well-run software projects
+        # that build with -Werror.  So if the active version of Clang has
+        # this misfeature, we search for an option to squash it.
+
+        AC_CACHE_CHECK([whether Clang needs flag to prevent "argument unused" warning when linking with -pthread],
+            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG],
+            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG=unknown
+             # Create an alternate version of $ac_link that compiles and
+             # links in two steps (.c -> .o, .o -> exe) instead of one
+             # (.c -> exe), because the warning occurs only in the second
+             # step
+             ax_pthread_save_ac_link="$ac_link"
+             ax_pthread_sed='s/conftest\.\$ac_ext/conftest.$ac_objext/g'
+             ax_pthread_link_step=`$as_echo "$ac_link" | sed "$ax_pthread_sed"`
+             ax_pthread_2step_ac_link="($ac_compile) && (echo ==== >&5) && ($ax_pthread_link_step)"
+             ax_pthread_save_CFLAGS="$CFLAGS"
+             for ax_pthread_try in '' -Qunused-arguments -Wno-unused-command-line-argument unknown; do
+                AS_IF([test "x$ax_pthread_try" = "xunknown"], [break])
+                CFLAGS="-Werror -Wunknown-warning-option $ax_pthread_try -pthread $ax_pthread_save_CFLAGS"
+                ac_link="$ax_pthread_save_ac_link"
+                AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
+                    [ac_link="$ax_pthread_2step_ac_link"
+                     AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
+                         [break])
+                    ])
+             done
+             ac_link="$ax_pthread_save_ac_link"
+             CFLAGS="$ax_pthread_save_CFLAGS"
+             AS_IF([test "x$ax_pthread_try" = "x"], [ax_pthread_try=no])
+             ax_cv_PTHREAD_CLANG_NO_WARN_FLAG="$ax_pthread_try"
+            ])
+
+        case "$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG" in
+                no | unknown) ;;
+                *) PTHREAD_CFLAGS="$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG $PTHREAD_CFLAGS" ;;
+        esac
+
+fi # $ax_pthread_clang = yes
+
+if test "x$ax_pthread_ok" = "xno"; then
+for ax_pthread_try_flag in $ax_pthread_flags; do
+
+        case $ax_pthread_try_flag in
+                none)
+                AC_MSG_CHECKING([whether pthreads work without any flags])
+                ;;
+
+                -mt,pthread)
+                AC_MSG_CHECKING([whether pthreads work with -mt -lpthread])
+                PTHREAD_CFLAGS="-mt"
+                PTHREAD_LIBS="-lpthread"
+                ;;
+
+                -*)
+                AC_MSG_CHECKING([whether pthreads work with $ax_pthread_try_flag])
+                PTHREAD_CFLAGS="$ax_pthread_try_flag"
+                ;;
+
+                pthread-config)
+                AC_CHECK_PROG([ax_pthread_config], [pthread-config], [yes], [no])
+                AS_IF([test "x$ax_pthread_config" = "xno"], [continue])
+                PTHREAD_CFLAGS="`pthread-config --cflags`"
+                PTHREAD_LIBS="`pthread-config --ldflags` `pthread-config --libs`"
+                ;;
+
+                *)
+                AC_MSG_CHECKING([for the pthreads library -l$ax_pthread_try_flag])
+                PTHREAD_LIBS="-l$ax_pthread_try_flag"
+                ;;
+        esac
+
+        ax_pthread_save_CFLAGS="$CFLAGS"
+        ax_pthread_save_LIBS="$LIBS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+
+        # Check for various functions.  We must include pthread.h,
+        # since some functions may be macros.  (On the Sequent, we
+        # need a special flag -Kthread to make this header compile.)
+        # We check for pthread_join because it is in -lpthread on IRIX
+        # while pthread_create is in libc.  We check for pthread_attr_init
+        # due to DEC craziness with -lpthreads.  We check for
+        # pthread_cleanup_push because it is one of the few pthread
+        # functions on Solaris that doesn't have a non-functional libc stub.
+        # We try pthread_create on general principles.
+
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <pthread.h>
+#                       if $ax_pthread_check_cond
+#                        error "$ax_pthread_check_macro must be defined"
+#                       endif
+                        static void routine(void *a) { a = 0; }
+                        static void *start_routine(void *a) { return a; }],
+                       [pthread_t th; pthread_attr_t attr;
+                        pthread_create(&th, 0, start_routine, 0);
+                        pthread_join(th, 0);
+                        pthread_attr_init(&attr);
+                        pthread_cleanup_push(routine, 0);
+                        pthread_cleanup_pop(0) /* ; */])],
+            [ax_pthread_ok=yes],
+            [])
+
+        CFLAGS="$ax_pthread_save_CFLAGS"
+        LIBS="$ax_pthread_save_LIBS"
+
+        AC_MSG_RESULT([$ax_pthread_ok])
+        AS_IF([test "x$ax_pthread_ok" = "xyes"], [break])
+
+        PTHREAD_LIBS=""
+        PTHREAD_CFLAGS=""
+done
+fi
+
+# Various other checks:
+if test "x$ax_pthread_ok" = "xyes"; then
+        ax_pthread_save_CFLAGS="$CFLAGS"
+        ax_pthread_save_LIBS="$LIBS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+
+        # Detect AIX lossage: JOINABLE attribute is called UNDETACHED.
+        AC_CACHE_CHECK([for joinable pthread attribute],
+            [ax_cv_PTHREAD_JOINABLE_ATTR],
+            [ax_cv_PTHREAD_JOINABLE_ATTR=unknown
+             for ax_pthread_attr in PTHREAD_CREATE_JOINABLE PTHREAD_CREATE_UNDETACHED; do
+                 AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <pthread.h>],
+                                                 [int attr = $ax_pthread_attr; return attr /* ; */])],
+                                [ax_cv_PTHREAD_JOINABLE_ATTR=$ax_pthread_attr; break],
+                                [])
+             done
+            ])
+        AS_IF([test "x$ax_cv_PTHREAD_JOINABLE_ATTR" != "xunknown" && \
+               test "x$ax_cv_PTHREAD_JOINABLE_ATTR" != "xPTHREAD_CREATE_JOINABLE" && \
+               test "x$ax_pthread_joinable_attr_defined" != "xyes"],
+              [AC_DEFINE_UNQUOTED([PTHREAD_CREATE_JOINABLE],
+                                  [$ax_cv_PTHREAD_JOINABLE_ATTR],
+                                  [Define to necessary symbol if this constant
+                                   uses a non-standard name on your system.])
+               ax_pthread_joinable_attr_defined=yes
+              ])
+
+        AC_CACHE_CHECK([whether more special flags are required for pthreads],
+            [ax_cv_PTHREAD_SPECIAL_FLAGS],
+            [ax_cv_PTHREAD_SPECIAL_FLAGS=no
+             case $host_os in
+             solaris*)
+             ax_cv_PTHREAD_SPECIAL_FLAGS="-D_POSIX_PTHREAD_SEMANTICS"
+             ;;
+             esac
+            ])
+        AS_IF([test "x$ax_cv_PTHREAD_SPECIAL_FLAGS" != "xno" && \
+               test "x$ax_pthread_special_flags_added" != "xyes"],
+              [PTHREAD_CFLAGS="$ax_cv_PTHREAD_SPECIAL_FLAGS $PTHREAD_CFLAGS"
+               ax_pthread_special_flags_added=yes])
+
+        AC_CACHE_CHECK([for PTHREAD_PRIO_INHERIT],
+            [ax_cv_PTHREAD_PRIO_INHERIT],
+            [AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <pthread.h>]],
+                                             [[int i = PTHREAD_PRIO_INHERIT;]])],
+                            [ax_cv_PTHREAD_PRIO_INHERIT=yes],
+                            [ax_cv_PTHREAD_PRIO_INHERIT=no])
+            ])
+        AS_IF([test "x$ax_cv_PTHREAD_PRIO_INHERIT" = "xyes" && \
+               test "x$ax_pthread_prio_inherit_defined" != "xyes"],
+              [AC_DEFINE([HAVE_PTHREAD_PRIO_INHERIT], [1], [Have PTHREAD_PRIO_INHERIT.])
+               ax_pthread_prio_inherit_defined=yes
+              ])
+
+        CFLAGS="$ax_pthread_save_CFLAGS"
+        LIBS="$ax_pthread_save_LIBS"
+
+        # More AIX lossage: compile with *_r variant
+        if test "x$GCC" != "xyes"; then
+            case $host_os in
+                aix*)
+                AS_CASE(["x/$CC"],
+                    [x*/c89|x*/c89_128|x*/c99|x*/c99_128|x*/cc|x*/cc128|x*/xlc|x*/xlc_v6|x*/xlc128|x*/xlc128_v6],
+                    [#handle absolute path differently from PATH based program lookup
+                     AS_CASE(["x$CC"],
+                         [x/*],
+                         [AS_IF([AS_EXECUTABLE_P([${CC}_r])],[PTHREAD_CC="${CC}_r"])],
+                         [AC_CHECK_PROGS([PTHREAD_CC],[${CC}_r],[$CC])])])
+                ;;
+            esac
+        fi
+fi
+
+test -n "$PTHREAD_CC" || PTHREAD_CC="$CC"
+
+AC_SUBST([PTHREAD_LIBS])
+AC_SUBST([PTHREAD_CFLAGS])
+AC_SUBST([PTHREAD_CC])
+
+# Finally, execute ACTION-IF-FOUND/ACTION-IF-NOT-FOUND:
+if test "x$ax_pthread_ok" = "xyes"; then
+        ifelse([$1],,[AC_DEFINE([HAVE_PTHREAD],[1],[Define if you have POSIX threads libraries and header files.])],[$1])
+        :
+else
+        ax_pthread_ok=no
+        $2
+fi
+AC_LANG_POP
+])dnl AX_PTHREAD

--- a/src/backend/openssl/cipher-aesgcm.c
+++ b/src/backend/openssl/cipher-aesgcm.c
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2016 Southern Storm Software, Pty Ltd.
+ * Copyright (C) 2016 Topology LP.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "internal.h"
+#include <openssl/conf.h>
+#include <openssl/evp.h>
+#include <openssl/err.h>
+#include <string.h>
+
+typedef struct
+{
+    struct NoiseCipherState_s parent;
+    EVP_CIPHER_CTX *ctx;
+
+	uint8_t iv[12];
+    uint8_t key[32];
+} NoiseAESGCMState;
+
+static void noise_aesgcm_init_key
+    (NoiseCipherState *state, const uint8_t *key)
+{
+    NoiseAESGCMState *st = (NoiseAESGCMState *)state;
+
+    memcpy(st->key, key, 32);
+}
+
+#define PUT_UINT64_BE(buf, value) \
+    do { \
+        uint64_t _value = (value); \
+        (buf)[0] = (uint8_t)(_value >> 56); \
+        (buf)[1] = (uint8_t)(_value >> 48); \
+        (buf)[2] = (uint8_t)(_value >> 40); \
+        (buf)[3] = (uint8_t)(_value >> 32); \
+        (buf)[4] = (uint8_t)(_value >> 24); \
+        (buf)[5] = (uint8_t)(_value >> 16); \
+        (buf)[6] = (uint8_t)(_value >> 8); \
+        (buf)[7] = (uint8_t)_value; \
+    } while (0)
+
+/**
+ * \brief Sets up the IV to start encrypting or decrypting a block.
+ *
+ * \param st The cipher state for AESGCM.
+ */
+static void noise_aesgcm_setup_iv(NoiseAESGCMState *st)
+{
+    /* The 96-bit nonce is formed by encoding 32 bits of zeros followed by big-endian encoding of n */
+    memset(st->iv, 0, 4);
+    PUT_UINT64_BE(st->iv + 4, st->parent.n);
+}
+
+static int noise_aesgcm_encrypt(NoiseCipherState *state, const uint8_t *ad, size_t ad_len, uint8_t *data, size_t data_len)
+{
+    NoiseAESGCMState *st = (NoiseAESGCMState *)state;
+
+    if (EVP_CIPHER_CTX_cleanup(st->ctx) <= 0) {
+        ERR_clear_error();
+        return NOISE_ERROR_SYSTEM;
+    }
+
+    noise_aesgcm_setup_iv(st);
+
+    if (EVP_EncryptInit_ex(st->ctx, EVP_aes_256_gcm(), NULL, st->key, st->iv) != 1) {
+        ERR_clear_error();
+        return NOISE_ERROR_SYSTEM;
+    }
+
+    /* Provide any AAD data. This can be called zero or more times as
+     * required
+     */
+    int len;
+    if (ad_len > 0) {
+        if (EVP_EncryptUpdate(st->ctx, NULL, &len, ad, ad_len) != 1) {
+            ERR_clear_error();
+            return NOISE_ERROR_SYSTEM;
+        }
+    }
+
+    /* Provide the message to be encrypted, and obtain the encrypted output.
+     * EVP_EncryptUpdate can be called multiple times if necessary
+     */
+    uint8_t out[data_len];
+    if (EVP_EncryptUpdate(st->ctx, out, &len, data, data_len) != 1) {
+        ERR_clear_error();
+        return NOISE_ERROR_SYSTEM;
+    }
+    int ciphertext_len = len;
+
+    /* Finalise the encryption. Normally ciphertext bytes may be written at
+     * this stage, but this does not occur in GCM mode
+     */
+    if (EVP_EncryptFinal_ex(st->ctx, out + len, &len) != 1) {
+        ERR_clear_error();
+        return NOISE_ERROR_SYSTEM;
+    }
+    ciphertext_len += len;
+
+    /* Get the tag */
+    if (EVP_CIPHER_CTX_ctrl(st->ctx, EVP_CTRL_GCM_GET_TAG, 16, data + ciphertext_len) != 1) {
+        ERR_clear_error();
+        return NOISE_ERROR_SYSTEM;
+    }
+
+    memcpy(data, out, ciphertext_len);
+
+    return NOISE_ERROR_NONE;
+}
+
+static int noise_aesgcm_decrypt(NoiseCipherState *state, const uint8_t *ad, size_t ad_len, uint8_t *data, size_t data_len)
+{
+    NoiseAESGCMState *st = (NoiseAESGCMState *)state;
+
+    if (EVP_CIPHER_CTX_cleanup(st->ctx) <= 0) {
+        ERR_clear_error();
+        return NOISE_ERROR_SYSTEM;
+    }
+
+    noise_aesgcm_setup_iv(st);
+
+    if (EVP_DecryptInit_ex(st->ctx, EVP_aes_256_gcm(), NULL, st->key, st->iv) != 1) {
+        ERR_clear_error();
+        return NOISE_ERROR_SYSTEM;
+    }
+
+    /* Provide any AAD data. This can be called zero or more times as
+     * required
+     */
+    int len;
+    if (ad_len > 0) {
+        if (!EVP_DecryptUpdate(st->ctx, NULL, &len, ad, ad_len)) {
+            ERR_clear_error();
+            return NOISE_ERROR_SYSTEM;
+        }
+    }
+
+    /* Provide the message to be decrypted, and obtain the plaintext output.
+     * EVP_DecryptUpdate can be called multiple times if necessary
+     */
+    if (!EVP_DecryptUpdate(st->ctx, data, &len, data, data_len)) {
+        ERR_clear_error();
+        return NOISE_ERROR_SYSTEM;
+    }
+
+    /* Set expected tag value. Works in OpenSSL 1.0.1d and later */
+    if (!EVP_CIPHER_CTX_ctrl(st->ctx, EVP_CTRL_GCM_SET_TAG, 16, data + len)) {
+        ERR_clear_error();
+        return NOISE_ERROR_SYSTEM;
+    }
+
+    /* Finalise the decryption. A positive return value indicates success,
+     * anything else is a failure - the plaintext is not trustworthy.
+     */
+    if (EVP_DecryptFinal_ex(st->ctx, data + len, &len) <= 0) {
+        ERR_clear_error();
+        return NOISE_ERROR_MAC_FAILURE;
+    }
+
+    return NOISE_ERROR_NONE;
+}
+
+void noise_aesgcm_free(NoiseCipherState *state)
+{
+    NoiseAESGCMState *st = (NoiseAESGCMState *)state;
+
+    EVP_CIPHER_CTX_free(st->ctx);
+}
+
+NoiseCipherState *noise_aesgcm_new_openssl(void)
+{
+    NoiseAESGCMState *state = noise_new(NoiseAESGCMState);
+    if (!state)
+        return 0;
+    if (!(state->ctx = EVP_CIPHER_CTX_new()))
+        return 0;
+    state->parent.cipher_id = NOISE_CIPHER_AESGCM;
+    state->parent.key_len = 32;
+    state->parent.mac_len = 16;
+    state->parent.create = noise_aesgcm_new_openssl;
+    state->parent.destroy = noise_aesgcm_free;
+    state->parent.init_key = noise_aesgcm_init_key;
+    state->parent.encrypt = noise_aesgcm_encrypt;
+    state->parent.decrypt = noise_aesgcm_decrypt;
+    return &(state->parent);
+}

--- a/src/backend/ref/cipher-aesgcm.c
+++ b/src/backend/ref/cipher-aesgcm.c
@@ -187,7 +187,7 @@ static int noise_aesgcm_decrypt
     return NOISE_ERROR_NONE;
 }
 
-NoiseCipherState *noise_aesgcm_new(void)
+NoiseCipherState *noise_aesgcm_new_ref(void)
 {
     NoiseAESGCMState *state = noise_new(NoiseAESGCMState);
     if (!state)
@@ -195,7 +195,7 @@ NoiseCipherState *noise_aesgcm_new(void)
     state->parent.cipher_id = NOISE_CIPHER_AESGCM;
     state->parent.key_len = 32;
     state->parent.mac_len = 16;
-    state->parent.create = noise_aesgcm_new;
+    state->parent.create = noise_aesgcm_new_ref;
     state->parent.init_key = noise_aesgcm_init_key;
     state->parent.encrypt = noise_aesgcm_encrypt;
     state->parent.decrypt = noise_aesgcm_decrypt;

--- a/src/backend/ref/dh-newhope.c
+++ b/src/backend/ref/dh-newhope.c
@@ -176,8 +176,10 @@ NoiseDHState *noise_newhope_new(void)
     return &(state->parent);
 }
 
+#if !USE_LIBSODIUM
 /* Implementation of random number generation needed by New Hope */
 void randombytes(unsigned char *x,unsigned long long xlen)
 {
     noise_rand_bytes(x, (size_t)xlen);
 }
+#endif

--- a/src/backend/sodium/cipher-aesgcm.c
+++ b/src/backend/sodium/cipher-aesgcm.c
@@ -88,7 +88,7 @@ static int noise_aesgcm_decrypt
     return NOISE_ERROR_NONE;
 }
 
-NoiseCipherState *noise_aesgcm_new(void)
+NoiseCipherState *noise_aesgcm_new_sodium(void)
 {
     NoiseAESGCMState *state = noise_new(NoiseAESGCMState);
     if (!state)
@@ -96,7 +96,7 @@ NoiseCipherState *noise_aesgcm_new(void)
     state->parent.cipher_id = NOISE_CIPHER_AESGCM;
     state->parent.key_len = crypto_aead_aes256gcm_KEYBYTES;
     state->parent.mac_len = crypto_aead_aes256gcm_ABYTES;
-    state->parent.create = noise_aesgcm_new;
+    state->parent.create = noise_aesgcm_new_sodium;
     state->parent.init_key = noise_aesgcm_init_key;
     state->parent.encrypt = noise_aesgcm_encrypt;
     state->parent.decrypt = noise_aesgcm_decrypt;

--- a/src/backend/sodium/cipher-aesgcm.c
+++ b/src/backend/sodium/cipher-aesgcm.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2016 Southern Storm Software, Pty Ltd.
+ * Copyright (C) 2016 Topology LP.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "internal.h"
+#include <sodium.h>
+#include <string.h>
+
+typedef struct
+{
+    struct NoiseCipherState_s parent;
+    crypto_aead_aes256gcm_state context;
+    uint8_t nonce[crypto_aead_aes256gcm_NPUBBYTES];
+    uint8_t key[crypto_aead_aes256gcm_KEYBYTES];
+} NoiseAESGCMState;
+
+static void noise_aesgcm_init_key
+    (NoiseCipherState *state, const uint8_t *key)
+{
+    NoiseAESGCMState *st = (NoiseAESGCMState *)state;
+
+    memcpy(st->key, key, crypto_aead_aes256gcm_KEYBYTES);
+    crypto_aead_aes256gcm_beforenm(&st->context, key);
+}
+
+#define PUT_UINT64_BE(buf, value) \
+    do { \
+        uint64_t _value = (value); \
+        (buf)[0] = (uint8_t)(_value >> 56); \
+        (buf)[1] = (uint8_t)(_value >> 48); \
+        (buf)[2] = (uint8_t)(_value >> 40); \
+        (buf)[3] = (uint8_t)(_value >> 32); \
+        (buf)[4] = (uint8_t)(_value >> 24); \
+        (buf)[5] = (uint8_t)(_value >> 16); \
+        (buf)[6] = (uint8_t)(_value >> 8); \
+        (buf)[7] = (uint8_t)_value; \
+    } while (0)
+
+/**
+ * \brief Sets up the IV to start encrypting or decrypting a block.
+ *
+ * \param st The cipher state for AESGCM.
+ */
+static void noise_aesgcm_setup_iv(NoiseAESGCMState *st)
+{
+    /* The 96-bit nonce is formed by encoding 32 bits of zeros followed by big-endian encoding of n */
+    memset(st->nonce, 0, 4);
+    PUT_UINT64_BE(st->nonce + 4, st->parent.n);
+}
+
+static int noise_aesgcm_encrypt
+    (NoiseCipherState *state, const uint8_t *ad, size_t ad_len,
+     uint8_t *data, size_t len)
+{
+    NoiseAESGCMState *st = (NoiseAESGCMState *)state;
+    noise_aesgcm_setup_iv(st);
+    crypto_aead_aes256gcm_encrypt_afternm(data, NULL, data, len, ad, ad_len, NULL, st->nonce, &st->context);
+    return NOISE_ERROR_NONE;
+}
+
+static int noise_aesgcm_decrypt
+    (NoiseCipherState *state, const uint8_t *ad, size_t ad_len,
+     uint8_t *data, size_t len)
+{
+    NoiseAESGCMState *st = (NoiseAESGCMState *)state;
+    noise_aesgcm_setup_iv(st);
+    if (crypto_aead_aes256gcm_decrypt_afternm(data, NULL, NULL, data, len + crypto_aead_aes256gcm_ABYTES, ad, ad_len, st->nonce, &st->context) < 0)
+        return NOISE_ERROR_MAC_FAILURE;
+    return NOISE_ERROR_NONE;
+}
+
+NoiseCipherState *noise_aesgcm_new(void)
+{
+    NoiseAESGCMState *state = noise_new(NoiseAESGCMState);
+    if (!state)
+        return 0;
+    state->parent.cipher_id = NOISE_CIPHER_AESGCM;
+    state->parent.key_len = crypto_aead_aes256gcm_KEYBYTES;
+    state->parent.mac_len = crypto_aead_aes256gcm_ABYTES;
+    state->parent.create = noise_aesgcm_new;
+    state->parent.init_key = noise_aesgcm_init_key;
+    state->parent.encrypt = noise_aesgcm_encrypt;
+    state->parent.decrypt = noise_aesgcm_decrypt;
+    return &(state->parent);
+}

--- a/src/backend/sodium/cipher-chachapoly.c
+++ b/src/backend/sodium/cipher-chachapoly.c
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2016 Southern Storm Software, Pty Ltd.
+ * Copyright (C) 2016 Topology LP.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "internal.h"
+#include <sodium.h>
+#include <string.h>
+
+typedef struct
+{
+    struct NoiseCipherState_s parent;
+    uint8_t chacha_k[crypto_stream_chacha20_KEYBYTES];
+    uint8_t chacha_n[crypto_stream_chacha20_IETF_NONCEBYTES];
+    crypto_onetimeauth_poly1305_state poly1305;
+    uint8_t block[64];
+
+} NoiseChaChaPolyState;
+
+static void noise_chachapoly_init_key
+    (NoiseCipherState *state, const uint8_t *key)
+{
+    NoiseChaChaPolyState *st = (NoiseChaChaPolyState *)state;
+    memcpy(st->chacha_k, key, crypto_stream_chacha20_KEYBYTES);
+}
+
+#define PUT_UINT64_LE(buf, value) \
+    do { \
+        (buf)[0] = (uint8_t)(value); \
+        (buf)[1] = (uint8_t)((value) >> 8); \
+        (buf)[2] = (uint8_t)((value) >> 16); \
+        (buf)[3] = (uint8_t)((value) >> 24); \
+        (buf)[4] = (uint8_t)((value) >> 32); \
+        (buf)[5] = (uint8_t)((value) >> 40); \
+        (buf)[6] = (uint8_t)((value) >> 48); \
+        (buf)[7] = (uint8_t)((value) >> 56); \
+    } while (0)
+
+/**
+ * \brief Sets up a ChaChaPoly context to encrypt/decrypt a block.
+ *
+ * \param st The encryption state for ChaChaPoly.
+ * \param n The nonce for this block.
+ */
+static void noise_chachapoly_setup(NoiseChaChaPolyState *st, uint64_t n)
+{
+    /* The 96-bit nonce is formed by encoding 32 bits of zeros followed by little-endian encoding of n */
+    memset(st->chacha_n, 0, 4);
+    PUT_UINT64_LE(st->chacha_n + 4, n);
+
+    /* Encrypt an initial block to create the Poly1305 key */
+    memset(st->block, 0, 64);
+    crypto_stream_chacha20_ietf_xor(st->block, st->block, 64, st->chacha_n, st->chacha_k);
+    crypto_onetimeauth_poly1305_init(&(st->poly1305), st->block);
+    noise_clean(st->block, sizeof(st->block));
+}
+
+/**
+ * \brief Pads the Poly1305 input to a multiple of 16 bytes.
+ *
+ * \param st The encryption state for ChaChaPoly.
+ * \param len The length of the input that needs to be padded.
+ */
+static void noise_chachapoly_pad_auth(NoiseChaChaPolyState *st, size_t len)
+{
+    len %= 16;
+    if (len) {
+        static uint8_t const padding[16] = {
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        };
+        crypto_onetimeauth_poly1305_update(&(st->poly1305), padding, 16 - len);
+    }
+}
+
+/**
+ * \brief Finalize the Poly1305 hash by adding the lengths.
+ *
+ * \param st The encryption state for ChaChaPoly.
+ * \param ad_len The length of the associated data.
+ * \param data_len The length of the ciphertext.
+ */
+static void noise_chachapoly_auth_lengths
+    (NoiseChaChaPolyState *st, uint64_t ad_len, uint64_t data_len)
+{
+    PUT_UINT64_LE(st->block, ad_len);
+    PUT_UINT64_LE(st->block + 8, data_len);
+    crypto_onetimeauth_poly1305_update(&(st->poly1305), st->block, 16);
+}
+
+static int noise_chachapoly_encrypt
+    (NoiseCipherState *state, const uint8_t *ad, size_t ad_len,
+     uint8_t *data, size_t len)
+{
+    NoiseChaChaPolyState *st = (NoiseChaChaPolyState *)state;
+    noise_chachapoly_setup(st, state->n);
+    if (ad_len) {
+        crypto_onetimeauth_poly1305_update(&(st->poly1305), ad, ad_len);
+        noise_chachapoly_pad_auth(st, ad_len);
+    }
+    crypto_stream_chacha20_ietf_xor_ic(data, data, len, st->chacha_n, 1U, st->chacha_k);
+    crypto_onetimeauth_poly1305_update(&(st->poly1305), data, len);
+    noise_chachapoly_pad_auth(st, len);
+    noise_chachapoly_auth_lengths(st, ad_len, len);
+    crypto_onetimeauth_poly1305_final(&(st->poly1305), data + len);
+    return NOISE_ERROR_NONE;
+}
+
+static int noise_chachapoly_decrypt
+    (NoiseCipherState *state, const uint8_t *ad, size_t ad_len,
+     uint8_t *data, size_t len)
+{
+    NoiseChaChaPolyState *st = (NoiseChaChaPolyState *)state;
+    noise_chachapoly_setup(st, state->n);
+    if (ad_len) {
+        crypto_onetimeauth_poly1305_update(&(st->poly1305), ad, ad_len);
+        noise_chachapoly_pad_auth(st, ad_len);
+    }
+    crypto_onetimeauth_poly1305_update(&(st->poly1305), data, len);
+    noise_chachapoly_pad_auth(st, len);
+    noise_chachapoly_auth_lengths(st, ad_len, len);
+    crypto_onetimeauth_poly1305_final(&(st->poly1305), st->block);
+    if (!noise_is_equal(st->block, data + len, 16))
+        return NOISE_ERROR_MAC_FAILURE;
+    crypto_stream_chacha20_ietf_xor_ic(data, data, len, st->chacha_n, 1U, st->chacha_k);
+    return NOISE_ERROR_NONE;
+}
+
+NoiseCipherState *noise_chachapoly_new(void)
+{
+    NoiseChaChaPolyState *state = noise_new(NoiseChaChaPolyState);
+    if (!state)
+        return 0;
+    state->parent.cipher_id = NOISE_CIPHER_CHACHAPOLY;
+    state->parent.key_len = crypto_stream_chacha20_KEYBYTES;
+    state->parent.mac_len = crypto_onetimeauth_poly1305_BYTES;
+    state->parent.create = noise_chachapoly_new;
+    state->parent.init_key = noise_chachapoly_init_key;
+    state->parent.encrypt = noise_chachapoly_encrypt;
+    state->parent.decrypt = noise_chachapoly_decrypt;
+    return &(state->parent);
+}

--- a/src/backend/sodium/dh-curve25519.c
+++ b/src/backend/sodium/dh-curve25519.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2016 Southern Storm Software, Pty Ltd.
+ * Copyright (C) 2016 Topology LP.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "internal.h"
+#include <sodium.h>
+#include <string.h>
+
+/* We use ed25519's faster curved25519_scalarmult_basepoint() function
+   when deriving a public key from a private key.  Unfortunately ed25519
+   doesn't have an equivalent function for general curve25519 calculations
+   so we fall back to the curve25519-donna implementation for that. */
+
+int curve25519_donna(uint8_t *mypublic, const uint8_t *secret, const uint8_t *basepoint);
+
+typedef struct
+{
+    struct NoiseDHState_s parent;
+    uint8_t private_key[32];
+    uint8_t public_key[32];
+
+} NoiseCurve25519State;
+
+static int noise_curve25519_generate_keypair
+    (NoiseDHState *state, const NoiseDHState *other)
+{
+    NoiseCurve25519State *st = (NoiseCurve25519State *)state;
+    noise_rand_bytes(st->private_key, 32);
+    st->private_key[0] &= 0xF8;
+    st->private_key[31] = (st->private_key[31] & 0x7F) | 0x40;
+    crypto_scalarmult_curve25519_base(st->public_key, st->private_key);
+    return NOISE_ERROR_NONE;
+}
+
+static int noise_curve25519_set_keypair
+        (NoiseDHState *state, const uint8_t *private_key,
+         const uint8_t *public_key)
+{
+    /* Check that the public key actually corresponds to the private key */
+    NoiseCurve25519State *st = (NoiseCurve25519State *)state;
+    uint8_t temp[32];
+    int equal;
+    crypto_scalarmult_curve25519_base(temp, private_key);
+    equal = noise_is_equal(temp, public_key, 32);
+    memcpy(st->private_key, private_key, 32);
+    memcpy(st->public_key, public_key, 32);
+    return NOISE_ERROR_INVALID_PUBLIC_KEY & (equal - 1);
+}
+
+static int noise_curve25519_set_keypair_private
+        (NoiseDHState *state, const uint8_t *private_key)
+{
+    NoiseCurve25519State *st = (NoiseCurve25519State *)state;
+    memcpy(st->private_key, private_key, 32);
+    crypto_scalarmult_curve25519_base(st->public_key, st->private_key);
+    return NOISE_ERROR_NONE;
+}
+
+static int noise_curve25519_validate_public_key
+        (const NoiseDHState *state, const uint8_t *public_key)
+{
+    /* Nothing to do here yet */
+    return NOISE_ERROR_NONE;
+}
+
+static int noise_curve25519_copy
+    (NoiseDHState *state, const NoiseDHState *from, const NoiseDHState *other)
+{
+    NoiseCurve25519State *st = (NoiseCurve25519State *)state;
+    const NoiseCurve25519State *from_st = (const NoiseCurve25519State *)from;
+    memcpy(st->private_key, from_st->private_key, 32);
+    memcpy(st->public_key, from_st->public_key, 32);
+    return NOISE_ERROR_NONE;
+}
+
+static int noise_curve25519_calculate
+    (const NoiseDHState *private_key_state,
+     const NoiseDHState *public_key_state,
+     uint8_t *shared_key)
+{
+    /* Do we need to check that the public key is less than 2^255 - 19? */
+    curve25519_donna(shared_key, private_key_state->private_key,
+                     public_key_state->public_key);
+    return NOISE_ERROR_NONE;
+}
+
+NoiseDHState *noise_curve25519_new(void)
+{
+    NoiseCurve25519State *state = noise_new(NoiseCurve25519State);
+    if (!state)
+        return 0;
+    state->parent.dh_id = NOISE_DH_CURVE25519;
+    state->parent.nulls_allowed = 1;
+    state->parent.private_key_len = 32;
+    state->parent.public_key_len = 32;
+    state->parent.shared_key_len = 32;
+    state->parent.private_key = state->private_key;
+    state->parent.public_key = state->public_key;
+    state->parent.generate_keypair = noise_curve25519_generate_keypair;
+    state->parent.set_keypair = noise_curve25519_set_keypair;
+    state->parent.set_keypair_private = noise_curve25519_set_keypair_private;
+    state->parent.validate_public_key = noise_curve25519_validate_public_key;
+    state->parent.copy = noise_curve25519_copy;
+    state->parent.calculate = noise_curve25519_calculate;
+    return &(state->parent);
+}
+
+/* Choose the version of curve25519-donna based on the word size */
+#if __WORDSIZE == 64 && defined(__GNUC__)
+#include "crypto/donna/curve25519-donna-c64.c"
+#else
+#include "crypto/donna/curve25519-donna.c"
+#endif

--- a/src/backend/sodium/hash-blake2b.c
+++ b/src/backend/sodium/hash-blake2b.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2016 Southern Storm Software, Pty Ltd.
+ * Copyright (C) 2016 Topology LP.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "internal.h"
+#include <sodium.h>
+
+typedef struct
+{
+    struct NoiseHashState_s parent;
+    crypto_generichash_blake2b_state blake2;
+
+} NoiseBLAKE2bState;
+
+static void noise_blake2b_reset(NoiseHashState *state)
+{
+    NoiseBLAKE2bState *st = (NoiseBLAKE2bState *)state;
+    crypto_generichash_blake2b_init(&(st->blake2), NULL, 0, crypto_generichash_blake2b_BYTES_MAX);
+}
+
+static void noise_blake2b_update(NoiseHashState *state, const uint8_t *data, size_t len)
+{
+    NoiseBLAKE2bState *st = (NoiseBLAKE2bState *)state;
+    crypto_generichash_blake2b_update(&(st->blake2), data, len);
+}
+
+static void noise_blake2b_finalize(NoiseHashState *state, uint8_t *hash)
+{
+    NoiseBLAKE2bState *st = (NoiseBLAKE2bState *)state;
+    crypto_generichash_blake2b_final(&(st->blake2), hash, crypto_generichash_blake2b_BYTES_MAX);
+}
+
+NoiseHashState *noise_blake2b_new(void)
+{
+    NoiseBLAKE2bState *state = noise_new(NoiseBLAKE2bState);
+    if (!state)
+        return 0;
+    state->parent.hash_id = NOISE_HASH_BLAKE2b;
+    state->parent.hash_len = 64;
+    state->parent.block_len = 128;
+    state->parent.reset = noise_blake2b_reset;
+    state->parent.update = noise_blake2b_update;
+    state->parent.finalize = noise_blake2b_finalize;
+    return &(state->parent);
+}

--- a/src/backend/sodium/hash-sha256.c
+++ b/src/backend/sodium/hash-sha256.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2016 Southern Storm Software, Pty Ltd.
+ * Copyright (C) 2016 Topology LP.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "internal.h"
+#include <sodium.h>
+
+typedef struct
+{
+    struct NoiseHashState_s parent;
+    crypto_hash_sha256_state sha256;
+
+} NoiseSHA256State;
+
+static void noise_sha256_reset(NoiseHashState *state)
+{
+    NoiseSHA256State *st = (NoiseSHA256State *)state;
+    crypto_hash_sha256_init(&(st->sha256));
+}
+
+static void noise_sha256_update(NoiseHashState *state, const uint8_t *data, size_t len)
+{
+    NoiseSHA256State *st = (NoiseSHA256State *)state;
+    crypto_hash_sha256_update(&(st->sha256), data, len);
+}
+
+static void noise_sha256_finalize(NoiseHashState *state, uint8_t *hash)
+{
+    NoiseSHA256State *st = (NoiseSHA256State *)state;
+    crypto_hash_sha256_final(&(st->sha256), hash);
+}
+
+NoiseHashState *noise_sha256_new(void)
+{
+    NoiseSHA256State *state = noise_new(NoiseSHA256State);
+    if (!state)
+        return 0;
+    state->parent.hash_id = NOISE_HASH_SHA256;
+    state->parent.hash_len = 32;
+    state->parent.block_len = 64;
+    state->parent.reset = noise_sha256_reset;
+    state->parent.update = noise_sha256_update;
+    state->parent.finalize = noise_sha256_finalize;
+    return &(state->parent);
+}

--- a/src/backend/sodium/hash-sha512.c
+++ b/src/backend/sodium/hash-sha512.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2016 Southern Storm Software, Pty Ltd.
+ * Copyright (C) 2016 Topology LP.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "internal.h"
+#include <sodium.h>
+
+typedef struct
+{
+    struct NoiseHashState_s parent;
+    crypto_hash_sha512_state sha512;
+
+} NoiseSHA512State;
+
+static void noise_sha512_reset(NoiseHashState *state)
+{
+    NoiseSHA512State *st = (NoiseSHA512State *)state;
+    crypto_hash_sha512_init(&(st->sha512));
+}
+
+static void noise_sha512_update(NoiseHashState *state, const uint8_t *data, size_t len)
+{
+    NoiseSHA512State *st = (NoiseSHA512State *)state;
+    crypto_hash_sha512_update(&(st->sha512), data, len);
+}
+
+static void noise_sha512_finalize(NoiseHashState *state, uint8_t *hash)
+{
+    NoiseSHA512State *st = (NoiseSHA512State *)state;
+    crypto_hash_sha512_final(&(st->sha512), hash);
+}
+
+NoiseHashState *noise_sha512_new(void)
+{
+    NoiseSHA512State *state = noise_new(NoiseSHA512State);
+    if (!state)
+        return 0;
+    state->parent.hash_id = NOISE_HASH_SHA512;
+    state->parent.hash_len = 64;
+    state->parent.block_len = 128;
+    state->parent.reset = noise_sha512_reset;
+    state->parent.update = noise_sha512_update;
+    state->parent.finalize = noise_sha512_finalize;
+    return &(state->parent);
+}

--- a/src/backend/sodium/sign-ed25519.c
+++ b/src/backend/sodium/sign-ed25519.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2016 Southern Storm Software, Pty Ltd.
+ * Copyright (C) 2016 Topology LP.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "internal.h"
+#include <sodium.h>
+
+typedef struct
+{
+    struct NoiseSignState_s parent;
+    union {
+        struct {
+            uint8_t private_key[32];
+            uint8_t public_key[32];
+        };
+        uint8_t skpk[crypto_sign_ed25519_SECRETKEYBYTES]; // sodium uses this format
+    };
+
+} NoiseEd25519State;
+
+static void noise_ed25519_generate_keypair(NoiseSignState *state)
+{
+    NoiseEd25519State *st = (NoiseEd25519State *)state;
+    uint8_t temp_pk[crypto_sign_ed25519_PUBLICKEYBYTES];
+    crypto_sign_ed25519_keypair(temp_pk, st->skpk);
+}
+
+static int noise_ed25519_validate_keypair
+        (const NoiseSignState *state, const uint8_t *private_key,
+         const uint8_t *public_key)
+{
+    /* Check that the public key actually corresponds to the private key */
+    uint8_t temp[crypto_sign_ed25519_PUBLICKEYBYTES];
+    uint8_t temp_sk[crypto_sign_ed25519_SECRETKEYBYTES];
+    int equal;
+    crypto_sign_ed25519_seed_keypair(temp, temp_sk, private_key);
+    equal = noise_is_equal(temp, public_key, sizeof(temp));
+    return NOISE_ERROR_INVALID_PUBLIC_KEY & (equal - 1);
+}
+
+static int noise_ed25519_validate_public_key
+        (const NoiseSignState *state, const uint8_t *public_key)
+{
+    /* Nothing to do here yet */
+    return NOISE_ERROR_NONE;
+}
+
+static int noise_ed25519_derive_public_key
+        (const NoiseSignState *state, const uint8_t *private_key,
+         uint8_t *public_key)
+{
+    uint8_t temp_sk[crypto_sign_ed25519_SECRETKEYBYTES];
+    crypto_sign_ed25519_seed_keypair(public_key, temp_sk, private_key);
+    return NOISE_ERROR_NONE;
+}
+
+static int noise_ed25519_sign
+        (const NoiseSignState *state, const uint8_t *message,
+         size_t message_len, uint8_t *signature)
+{
+    const NoiseEd25519State *st = (const NoiseEd25519State *)state;
+    crypto_sign_ed25519_detached(signature, NULL, message, message_len, st->skpk);
+    return NOISE_ERROR_NONE;
+}
+
+static int noise_ed25519_verify
+        (const NoiseSignState *state, const uint8_t *message,
+         size_t message_len, const uint8_t *signature)
+{
+    const NoiseEd25519State *st = (const NoiseEd25519State *)state;
+    int result = crypto_sign_ed25519_verify_detached(signature,
+            message, message_len, st->public_key);
+    return result ? NOISE_ERROR_INVALID_SIGNATURE : NOISE_ERROR_NONE;
+}
+
+NoiseSignState *noise_ed25519_new(void)
+{
+    NoiseEd25519State *state = noise_new(NoiseEd25519State);
+    if (!state)
+        return 0;
+    state->parent.sign_id = NOISE_SIGN_ED25519;
+    state->parent.private_key_len = 32;
+    state->parent.public_key_len = 32;
+    state->parent.signature_len = 64;
+    state->parent.private_key = state->private_key;
+    state->parent.public_key = state->public_key;
+    state->parent.generate_keypair = noise_ed25519_generate_keypair;
+    state->parent.validate_keypair = noise_ed25519_validate_keypair;
+    state->parent.validate_public_key = noise_ed25519_validate_public_key;
+    state->parent.derive_public_key = noise_ed25519_derive_public_key;
+    state->parent.sign = noise_ed25519_sign;
+    state->parent.verify = noise_ed25519_verify;
+    return &(state->parent);
+}

--- a/src/protocol/Makefile.am
+++ b/src/protocol/Makefile.am
@@ -10,11 +10,17 @@ GOLDILOCKS_CPPFLAGS = \
 	-I$(GOLDILOCKS_SRCDIR)/p448 \
 	-I$(GOLDILOCKS_SRCDIR)/p448/@GOLDILOCKS_ARCH@
 
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src $(GOLDILOCKS_CPPFLAGS)
+AM_CFLAGS = @WARNING_FLAGS@
+
+if USE_LIBSODIUM
+AM_CPPFLAGS += -DUSE_LIBSODIUM=1
+AM_CFLAGS += $(libsodium_CFLAGS)
+else !USE_LIBSODIUM
 # Definitions for ed25519-donna (Ed25519 reference implementation)
 ED25519_CPPFLAGS = -DED25519_CUSTOMHASH -DED25519_CUSTOMRANDOM
-
-AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src $(GOLDILOCKS_CPPFLAGS) $(ED25519_CPPFLAGS)
-AM_CFLAGS = @WARNING_FLAGS@
+AM_CPPFLAGS += $(ED25519_CPPFLAGS)
+endif
 
 libnoiseprotocol_a_SOURCES = \
 	cipherstate.c \
@@ -26,34 +32,16 @@ libnoiseprotocol_a_SOURCES = \
 	names.c \
 	patterns.c \
 	randstate.c \
-	rand_os.c \
 	signstate.c \
 	symmetricstate.c \
 	util.c \
-	../backend/ref/cipher-aesgcm.c \
-	../backend/ref/cipher-chachapoly.c \
-	../backend/ref/dh-curve25519.c \
 	../backend/ref/dh-curve448.c \
 	../backend/ref/dh-newhope.c \
 	../backend/ref/hash-blake2s.c \
-	../backend/ref/hash-blake2b.c \
-	../backend/ref/hash-sha256.c \
-	../backend/ref/hash-sha512.c \
-	../backend/ref/sign-ed25519.c \
-	../crypto/aes/rijndael-alg-fst.c \
 	../crypto/blake2/blake2s.c \
-	../crypto/blake2/blake2b.c \
-	../crypto/chacha/chacha.c \
 	../crypto/curve448/curve448.c \
-	../crypto/donna/poly1305-donna.c \
-	../crypto/ghash/ghash.c \
-	../crypto/sha2/sha256.c \
-	../crypto/sha2/sha512.c \
 	../crypto/goldilocks/src/p448/@GOLDILOCKS_ARCH@/p448.c \
-	../crypto/ed25519/ed25519.c \
 	../crypto/newhope/batcher.c \
-	../crypto/newhope/crypto_stream_chacha20.c \
-	../crypto/newhope/crypto_stream_chacha20.h \
 	../crypto/newhope/error_correction.c \
 	../crypto/newhope/error_correction.h \
 	../crypto/newhope/fips202.c \
@@ -69,3 +57,35 @@ libnoiseprotocol_a_SOURCES = \
 	../crypto/newhope/randombytes.h \
 	../crypto/newhope/reduce.c \
 	../crypto/newhope/reduce.h
+
+if USE_LIBSODIUM
+libnoiseprotocol_a_SOURCES += \
+	rand_sodium.c \
+	../backend/sodium/cipher-aesgcm.c \
+	../backend/sodium/cipher-chachapoly.c \
+	../backend/sodium/dh-curve25519.c \
+	../backend/sodium/hash-blake2b.c \
+	../backend/sodium/hash-sha256.c \
+	../backend/sodium/hash-sha512.c \
+	../backend/sodium/sign-ed25519.c
+else !USE_LIBSODIUM
+libnoiseprotocol_a_SOURCES += \
+	rand_os.c \
+	../backend/ref/cipher-aesgcm.c \
+	../backend/ref/cipher-chachapoly.c \
+	../backend/ref/dh-curve25519.c \
+	../backend/ref/hash-blake2b.c \
+	../backend/ref/hash-sha256.c \
+	../backend/ref/hash-sha512.c \
+	../backend/ref/sign-ed25519.c \
+	../crypto/aes/rijndael-alg-fst.c \
+	../crypto/blake2/blake2b.c \
+	../crypto/chacha/chacha.c \
+	../crypto/donna/poly1305-donna.c \
+	../crypto/ghash/ghash.c \
+	../crypto/newhope/crypto_stream_chacha20.c \
+	../crypto/newhope/crypto_stream_chacha20.h \
+	../crypto/sha2/sha256.c \
+	../crypto/sha2/sha512.c \
+	../crypto/ed25519/ed25519.c
+endif

--- a/src/protocol/Makefile.am
+++ b/src/protocol/Makefile.am
@@ -13,6 +13,11 @@ GOLDILOCKS_CPPFLAGS = \
 AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src $(GOLDILOCKS_CPPFLAGS)
 AM_CFLAGS = @WARNING_FLAGS@
 
+if USE_OPENSSL
+AM_CPPFLAGS += -DUSE_OPENSSL=1
+AM_CFLAGS += $(openssl_CFLAGS)
+endif
+
 if USE_LIBSODIUM
 AM_CPPFLAGS += -DUSE_LIBSODIUM=1
 AM_CFLAGS += $(libsodium_CFLAGS)
@@ -28,7 +33,7 @@ libnoiseprotocol_a_SOURCES = \
 	errors.c \
 	handshakestate.c \
 	hashstate.c \
-	internal.h \
+	internal.c \
 	names.c \
 	patterns.c \
 	randstate.c \
@@ -57,6 +62,19 @@ libnoiseprotocol_a_SOURCES = \
 	../crypto/newhope/randombytes.h \
 	../crypto/newhope/reduce.c \
 	../crypto/newhope/reduce.h
+
+if USE_OPENSSL
+libnoiseprotocol_a_SOURCES += \
+	../backend/openssl/cipher-aesgcm.c
+else !USE_OPENSSL
+if USE_LIBSODIUM
+libnoiseprotocol_a_SOURCES += \
+	../backend/sodium/cipher-aesgcm.c
+else
+libnoiseprotocol_a_SOURCES += \
+	../backend/ref/cipher-aesgcm.c
+endif
+endif
 
 if USE_LIBSODIUM
 libnoiseprotocol_a_SOURCES += \

--- a/src/protocol/internal.c
+++ b/src/protocol/internal.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2016 Southern Storm Software, Pty Ltd.
+ * Copyright (C) 2016 Topology LP.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "internal.h"
+
+#if USE_SODIUM
+NoiseCipherState *noise_aesgcm_new_sodium(void);
+#endif
+#if USE_OPENSSL
+NoiseCipherState *noise_aesgcm_new_openssl(void);
+#else
+NoiseCipherState *noise_aesgcm_new_ref(void);
+#endif
+
+/**
+ * \brief Creates a new AES-GCM CipherState object.
+ *
+ * \return A NoiseCipherState for AES-GCM cipher use, or NULL if no such state is available.
+ */
+NoiseCipherState *noise_aesgcm_new(void)
+{
+    NoiseCipherState *state = 0;
+#if USE_SODIUM
+    if (crypto_aead_aes256gcm_is_available())
+        state = noise_aesgcm_new_sodium();
+#endif
+#if USE_OPENSSL
+    if (!state)
+        state = noise_aesgcm_new_openssl();
+#else
+    if (!state)
+        state = noise_aesgcm_new_ref();
+#endif
+
+    return state;
+}
+
+

--- a/src/protocol/rand_sodium.c
+++ b/src/protocol/rand_sodium.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2016 Southern Storm Software, Pty Ltd.
+ * Copyright (C) 2016 Topology LP.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#if USE_LIBSODIUM
+#include <sodium.h>
+
+/**
+ * \file rand_sodium.c
+ * \brief Generate random bytes using libsodium
+ */
+
+/**
+ * \brief Gets cryptographically-strong random bytes from the operating system.
+ *
+ * \param bytes The buffer to fill with random bytes.
+ * \param size The number of random bytes to obtain.
+ *
+ * This function should not block waiting for entropy.
+ *
+ * \note Not part of the public API.
+ */
+void noise_rand_bytes(void *bytes, size_t size)
+{
+    randombytes_buf(bytes, size);
+}
+
+
+#endif

--- a/src/protocol/randstate.c
+++ b/src/protocol/randstate.c
@@ -21,7 +21,11 @@
  */
 
 #include "internal.h"
+#if USE_LIBSODIUM
+#include <sodium.h>
+#else
 #include "crypto/chacha/chacha.h"
+#endif
 #include <string.h>
 
 /**
@@ -69,7 +73,12 @@ struct NoiseRandState_s
     size_t left;
 
     /** \brief ChaCha20 state for the random number generator */
+#if USE_LIBSODIUM
+    uint8_t chacha_k[crypto_stream_chacha20_KEYBYTES];
+    uint8_t chacha_n[crypto_stream_chacha20_IETF_NONCEBYTES];
+#else
     chacha_ctx chacha;
+#endif
 };
 
 /** Number of bytes to generate before forcing a reseed */
@@ -115,7 +124,12 @@ int noise_randstate_new(NoiseRandState **state)
         return NOISE_ERROR_NO_MEMORY;
 
     /* Initialize the random number generator */
+#if USE_LIBSODIUM
+    memcpy((*state)->chacha_k, starting_key, crypto_stream_chacha20_KEYBYTES);
+    memset((*state)->chacha_n, 0, crypto_stream_chacha20_IETF_NONCEBYTES);
+#else
     chacha_keysetup(&((*state)->chacha), starting_key, 256);
+#endif
     noise_randstate_reseed((*state));
     return NOISE_ERROR_NONE;
 }
@@ -162,7 +176,11 @@ int noise_randstate_free(NoiseRandState *state)
  */
 int noise_randstate_reseed(NoiseRandState *state)
 {
+#if USE_LIBSODIUM
+    uint8_t data[crypto_stream_chacha20_KEYBYTES + crypto_stream_chacha20_IETF_NONCEBYTES];
+#else
     uint8_t data[40];
+#endif
 
     /* Validate the parameter */
     if (!state)
@@ -171,16 +189,28 @@ int noise_randstate_reseed(NoiseRandState *state)
     /* Get new random data from the operating system, encrypt it
        with the previous key/IV, and then replace the key/IV */
     noise_rand_bytes(data, sizeof(data));
+#if USE_LIBSODIUM
+    crypto_stream_chacha20_ietf_xor(data, data, sizeof(data), state->chacha_n, state->chacha_k);
+    memcpy(state->chacha_k, data, crypto_stream_chacha20_KEYBYTES);
+    memcpy(state->chacha_n, data + crypto_stream_chacha20_KEYBYTES, crypto_stream_chacha20_IETF_NONCEBYTES);
+#else
     chacha_encrypt_bytes(&(state->chacha), data, data, sizeof(data));
     chacha_keysetup(&(state->chacha), data, 256);
     chacha_ivsetup(&(state->chacha), data + 32, 0);
+#endif
     state->left = NOISE_RAND_RESEED_COUNT;
 
     /* And force a rekey as well for good measure */
     memset(data, 0, sizeof(data));
+#if USE_LIBSODIUM
+    crypto_stream_chacha20_ietf_xor(data, data, sizeof(data), state->chacha_n, state->chacha_k);
+    memcpy(state->chacha_k, data, crypto_stream_chacha20_KEYBYTES);
+    memcpy(state->chacha_n, data + crypto_stream_chacha20_KEYBYTES, crypto_stream_chacha20_IETF_NONCEBYTES);
+#else
     chacha_encrypt_bytes(&(state->chacha), data, data, sizeof(data));
     chacha_keysetup(&(state->chacha), data, 256);
     chacha_ivsetup(&(state->chacha), data + 32, 0);
+#endif
     noise_clean(data, sizeof(data));
 
     /* Ready to go */
@@ -194,11 +224,21 @@ int noise_randstate_reseed(NoiseRandState *state)
  */
 static void noise_randstate_rekey(NoiseRandState *state)
 {
+#if USE_LIBSODIUM
+    uint8_t data[crypto_stream_chacha20_KEYBYTES + crypto_stream_chacha20_IETF_NONCEBYTES];
+#else
     uint8_t data[40];
+#endif
     memset(data, 0, sizeof(data));
+#if USE_LIBSODIUM
+    crypto_stream_chacha20_ietf_xor(data, data, sizeof(data), state->chacha_n, state->chacha_k);
+    memcpy(state->chacha_k, data, crypto_stream_chacha20_KEYBYTES);
+    memcpy(state->chacha_n, data + crypto_stream_chacha20_KEYBYTES, crypto_stream_chacha20_IETF_NONCEBYTES);
+#else
     chacha_encrypt_bytes(&(state->chacha), data, data, sizeof(data));
     chacha_keysetup(&(state->chacha), data, 256);
     chacha_ivsetup(&(state->chacha), data + 32, 0);
+#endif
     noise_clean(data, sizeof(data));
 }
 
@@ -259,7 +299,11 @@ int noise_randstate_generate
             noise_randstate_rekey(state);
             blocks = 0;
         }
+#if USE_LIBSODIUM
+        crypto_stream_chacha20_ietf_xor_ic(buffer, buffer, temp_len, state->chacha_n, blocks + 1, state->chacha_k);
+#else
         chacha_encrypt_bytes(&(state->chacha), buffer, buffer, temp_len);
+#endif
         buffer += temp_len;
         len -= temp_len;
     }
@@ -354,7 +398,12 @@ int noise_randstate_generate_simple(uint8_t *buffer, size_t len)
 
     /* Initialize the random number generator on the stack */
     memset(&state, 0, sizeof(state));
+#if USE_LIBSODIUM
+    memcpy(state.chacha_k, starting_key, crypto_stream_chacha20_KEYBYTES);
+    memset(state.chacha_n, 0, crypto_stream_chacha20_IETF_NONCEBYTES);
+#else
     chacha_keysetup(&(state.chacha), starting_key, 256);
+#endif
     noise_randstate_reseed(&state);
 
     /* Generate the required data */

--- a/src/protocol/util.c
+++ b/src/protocol/util.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Southern Storm Software, Pty Ltd.
+ * Copyright (C) 2016 Topology LP.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -30,7 +31,15 @@ typedef crypto_hash_sha256_state sha256_context_t;
 #else
 #include "crypto/sha2/sha256.h"
 #endif
+#if USE_OPENSSL
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#endif
 #include <stdlib.h>
+#if HAVE_PTHREAD
+#include <pthread.h>
+static pthread_once_t noise_is_initialized = PTHREAD_ONCE_INIT;
+#endif
 
 /**
  * \file util.h
@@ -41,6 +50,18 @@ typedef crypto_hash_sha256_state sha256_context_t;
  * \file util.c
  * \brief Utility function implementation
  */
+
+void noise_init_helper(void)
+{
+#if USE_LIBSODIUM
+    if (sodium_init() < 0)
+        return;
+#endif
+#if USE_OPENSSL
+    OpenSSL_add_all_algorithms();
+    ERR_load_crypto_strings();
+#endif
+}
 
 /**
  * \defgroup utils Utilities
@@ -53,6 +74,27 @@ typedef crypto_hash_sha256_state sha256_context_t;
  * hopefully not optimize away like it might optimize memset().
  */
 /**@{*/
+
+/**
+ * \fn noise_init()
+ * \brief Initializes the Noise-c library.
+ *
+ * \return NOISE_ERROR_NONE on success.
+ *
+ * This will initialize the underlying crypto libraries.
+ * You don't need to call this if you initialize the crypto libraries (eg. libsodium, OpenSSL) yourself.
+ */
+int noise_init(void)
+{
+#if HAVE_PTHREAD
+    if (pthread_once(&noise_is_initialized, noise_init_helper) != 0)
+        return NOISE_ERROR_SYSTEM;
+#else
+    noise_init_helper();
+#endif
+
+    return NOISE_ERROR_NONE;
+}
 
 /**
  * \def noise_new(type)

--- a/src/protocol/util.c
+++ b/src/protocol/util.c
@@ -21,7 +21,15 @@
  */
 
 #include "internal.h"
+#if USE_LIBSODIUM
+#include <sodium.h>
+typedef crypto_hash_sha256_state sha256_context_t;
+#define sha256_reset(ctx) crypto_hash_sha256_init(ctx)
+#define sha256_update(ctx, pub, pub_len) crypto_hash_sha256_update(ctx, pub, pub_len)
+#define sha256_finish(ctx, hash) crypto_hash_sha256_final(ctx, hash)
+#else
 #include "crypto/sha2/sha256.h"
+#endif
 #include <stdlib.h>
 
 /**

--- a/tests/performance/Makefile.am
+++ b/tests/performance/Makefile.am
@@ -13,3 +13,9 @@ AM_CPPFLAGS += -DUSE_LIBSODIUM=1
 AM_CFLAGS += $(libsodium_CFLAGS)
 LDADD += $(libsodium_LIBS)
 endif
+
+if USE_OPENSSL
+AM_CPPFLAGS += -DUSE_OPENSSL=1
+AM_CFLAGS += $(openssl_CFLAGS)
+LDADD += $(openssl_LIBS)
+endif

--- a/tests/performance/Makefile.am
+++ b/tests/performance/Makefile.am
@@ -7,3 +7,9 @@ AM_CPPFLAGS = -I$(top_srcdir)/include
 AM_CFLAGS = @WARNING_FLAGS@
 
 LDADD = ../../src/protocol/libnoiseprotocol.a
+
+if USE_LIBSODIUM
+AM_CPPFLAGS += -DUSE_LIBSODIUM=1
+AM_CFLAGS += $(libsodium_CFLAGS)
+LDADD += $(libsodium_LIBS)
+endif

--- a/tests/performance/test-performance.c
+++ b/tests/performance/test-performance.c
@@ -399,6 +399,11 @@ static void perf_sign_verify(int id)
 
 int main(int argc, char *argv[])
 {
+    if (noise_init() != NOISE_ERROR_NONE) {
+        fprintf(stderr, "Noise initialization failed\n");
+        return 1;
+    }
+
     /* Print the header */
     printf("Algorithm             MB/sec         MD5 units\n");
 

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -24,3 +24,9 @@ LDADD = ../../src/keys/libnoisekeys.a \
 
 check-local:
 	./test-noise
+
+if USE_LIBSODIUM
+AM_CPPFLAGS += -DUSE_LIBSODIUM=1
+AM_CFLAGS += $(libsodium_CFLAGS)
+LDADD += $(libsodium_LIBS)
+endif

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -30,3 +30,9 @@ AM_CPPFLAGS += -DUSE_LIBSODIUM=1
 AM_CFLAGS += $(libsodium_CFLAGS)
 LDADD += $(libsodium_LIBS)
 endif
+
+if USE_OPENSSL
+AM_CPPFLAGS += -DUSE_OPENSSL=1
+AM_CFLAGS += $(openssl_CFLAGS)
+LDADD += $(openssl_LIBS)
+endif

--- a/tests/unit/test-main.c
+++ b/tests/unit/test-main.c
@@ -34,6 +34,11 @@ int main(int argc, char *argv[])
     if (argc > 1 && !strcmp(argv[1], "--verbose"))
         verbose = 1;
 
+    if (noise_init() != NOISE_ERROR_NONE) {
+        fprintf(stderr, "Noise initialization failed\n");
+        return 1;
+    }
+
     /* Run all tests */
     test(cipherstate);
     test(dhstate);

--- a/tests/vector-gen/Makefile.am
+++ b/tests/vector-gen/Makefile.am
@@ -20,3 +20,9 @@ AM_CPPFLAGS += -DUSE_LIBSODIUM=1
 AM_CFLAGS += $(libsodium_CFLAGS)
 LDADD += $(libsodium_LIBS)
 endif
+
+if USE_OPENSSL
+AM_CPPFLAGS += -DUSE_OPENSSL=1
+AM_CFLAGS += $(openssl_CFLAGS)
+LDADD += $(openssl_LIBS)
+endif

--- a/tests/vector-gen/Makefile.am
+++ b/tests/vector-gen/Makefile.am
@@ -14,3 +14,9 @@ AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src/protocol
 AM_CFLAGS = @WARNING_FLAGS@
 
 LDADD = ../../src/protocol/libnoiseprotocol.a
+
+if USE_LIBSODIUM
+AM_CPPFLAGS += -DUSE_LIBSODIUM=1
+AM_CFLAGS += $(libsodium_CFLAGS)
+LDADD += $(libsodium_LIBS)
+endif

--- a/tests/vector-gen/vector-gen.c
+++ b/tests/vector-gen/vector-gen.c
@@ -1123,6 +1123,11 @@ static void hybrid_patterns(int with_ssk)
 
 int main(int argc, char *argv[])
 {
+    if (noise_init() != NOISE_ERROR_NONE) {
+        fprintf(stderr, "Noise initialization failed\n");
+        return 1;
+    }
+
     int with_ssk = 0;
     int with_fallback = 0;
     int with_hybrid = 0;

--- a/tests/vector/Makefile.am
+++ b/tests/vector/Makefile.am
@@ -25,3 +25,9 @@ AM_CPPFLAGS += -DUSE_LIBSODIUM=1
 AM_CFLAGS += $(libsodium_CFLAGS)
 LDADD += $(libsodium_LIBS)
 endif
+
+if USE_OPENSSL
+AM_CPPFLAGS += -DUSE_OPENSSL=1
+AM_CFLAGS += $(openssl_CFLAGS)
+LDADD += $(openssl_LIBS)
+endif

--- a/tests/vector/Makefile.am
+++ b/tests/vector/Makefile.am
@@ -19,3 +19,9 @@ check-local:
 	./test-vector $(VECTORS)
 
 EXTRA_DIST = $(VECTORS)
+
+if USE_LIBSODIUM
+AM_CPPFLAGS += -DUSE_LIBSODIUM=1
+AM_CFLAGS += $(libsodium_CFLAGS)
+LDADD += $(libsodium_LIBS)
+endif

--- a/tests/vector/test-vector.c
+++ b/tests/vector/test-vector.c
@@ -854,6 +854,11 @@ static int process_file(const char *filename)
 
 int main(int argc, char *argv[])
 {
+    if (noise_init() != NOISE_ERROR_NONE) {
+        fprintf(stderr, "Noise initialization failed\n");
+        return 1;
+    }
+
     int retval = 0;
     char *srcdir = getenv("srcdir");
     if (argc <= 1 && !srcdir) {

--- a/tools/keytool/Makefile.am
+++ b/tools/keytool/Makefile.am
@@ -19,3 +19,9 @@ AM_CPPFLAGS += -DUSE_LIBSODIUM=1
 AM_CFLAGS += $(libsodium_CFLAGS)
 LDADD += $(libsodium_LIBS)
 endif
+
+if USE_OPENSSL
+AM_CPPFLAGS += -DUSE_OPENSSL=1
+AM_CFLAGS += $(openssl_CFLAGS)
+LDADD += $(openssl_LIBS)
+endif

--- a/tools/keytool/Makefile.am
+++ b/tools/keytool/Makefile.am
@@ -13,3 +13,9 @@ AM_CFLAGS = @WARNING_FLAGS@
 LDADD = ../../src/keys/libnoisekeys.a \
         ../../src/protobufs/libnoiseprotobufs.a \
         ../../src/protocol/libnoiseprotocol.a
+
+if USE_LIBSODIUM
+AM_CPPFLAGS += -DUSE_LIBSODIUM=1
+AM_CFLAGS += $(libsodium_CFLAGS)
+LDADD += $(libsodium_LIBS)
+endif

--- a/tools/keytool/keytool.c
+++ b/tools/keytool/keytool.c
@@ -55,6 +55,11 @@ int main(int argc, char *argv[])
         return 1;
     }
 
+    if (noise_init() != NOISE_ERROR_NONE) {
+        fprintf(stderr, "Noise initialization failed\n");
+        return 1;
+    }
+
     /* Determine which subcommand to run */
     if (!strcmp(argv[1], "generate")) {
         retval = main_generate(progname, argc - 1, argv + 1);


### PR DESCRIPTION
This includes two new crypto backends, OpenSSL for AES-GCM and libsodium for many primitives.

It also includes a libsodium random implementation and a new noise_init() function to initialize the crypto backends (if necessary).