### PR TITLE
We're building the Noise libraries statically, so we need the static flags for dependent libraries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,9 +75,9 @@ AC_ARG_WITH([libsodium],
   [],
   [with_libsodium=no])
 AS_CASE(["$with_libsodium"],
-  [yes], [PKG_CHECK_MODULES([libsodium], [libsodium], [HAVE_LIBSODIUM=1])],
+  [yes], [PKG_CHECK_MODULES_STATIC([libsodium], [libsodium], [HAVE_LIBSODIUM=1])],
   [no], [HAVE_LIBSODIUM=0],
-  [PKG_CHECK_MODULES([libsodium], [libsodium], [HAVE_LIBSODIUM=1], [HAVE_LIBSODIUM=0])])
+  [PKG_CHECK_MODULES_STATIC([libsodium], [libsodium], [HAVE_LIBSODIUM=1], [HAVE_LIBSODIUM=0])])
 AM_CONDITIONAL([USE_LIBSODIUM], [test "$with_libsodium" != no -a "$HAVE_LIBSODIUM" -eq 1])
 
 AC_ARG_WITH([openssl],
@@ -86,9 +86,9 @@ AC_ARG_WITH([openssl],
   [],
   [with_openssl=no])
 AS_CASE(["$with_openssl"],
-  [yes], [PKG_CHECK_MODULES([openssl], [openssl], [HAVE_OPENSSL=1])],
+  [yes], [PKG_CHECK_MODULES_STATIC([openssl], [openssl], [HAVE_OPENSSL=1])],
   [no], [HAVE_OPENSSL=0],
-  [PKG_CHECK_MODULES([openssl], [openssl], [HAVE_OPENSSL=1], [HAVE_OPENSSL=0])])
+  [PKG_CHECK_MODULES_STATIC([openssl], [openssl], [HAVE_OPENSSL=1], [HAVE_OPENSSL=0])])
 AM_CONDITIONAL([USE_OPENSSL], [test "$with_openssl" != no -a "$HAVE_OPENSSL" -eq 1])
 
 AC_OUTPUT


### PR DESCRIPTION
On Linux, OpenSSL libs need -ldl when linked statically