### PR TITLE
Fix for incorrect includes and `warning: unresolved symbol` messages

### DIFF
--- a/src/backend/ref/cipher-aesgcm.c
+++ b/src/backend/ref/cipher-aesgcm.c
@@ -20,9 +20,9 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "internal.h"
-#include "crypto/aes/rijndael-alg-fst.h"
-#include "crypto/ghash/ghash.h"
+#include <protocol/internal.h>
+#include <crypto/aes/rijndael-alg-fst.h>
+#include <crypto/ghash/ghash.c>
 #include <string.h>
 
 typedef struct

--- a/src/backend/ref/cipher-chachapoly.c
+++ b/src/backend/ref/cipher-chachapoly.c
@@ -20,9 +20,9 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "internal.h"
-#include "crypto/chacha/chacha.h"
-#include "crypto/donna/poly1305-donna.h"
+#include <protocol/internal.h>
+#include <crypto/chacha/chacha.c>
+#include <crypto/donna/poly1305-donna.c>
 #include <string.h>
 
 typedef struct

--- a/src/backend/ref/dh-curve25519.c
+++ b/src/backend/ref/dh-curve25519.c
@@ -20,8 +20,8 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "internal.h"
-#include "crypto/ed25519/ed25519.h"
+#include <protocol/internal.h>
+#include <crypto/ed25519/ed25519.c>
 #include <string.h>
 
 /* We use ed25519's faster curved25519_scalarmult_basepoint() function

--- a/src/backend/ref/dh-curve448.c
+++ b/src/backend/ref/dh-curve448.c
@@ -20,8 +20,8 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "internal.h"
-#include "crypto/curve448/curve448.h"
+#include <protocol/internal.h>
+#include <crypto/curve448/curve448.c>
 #include <string.h>
 
 typedef struct

--- a/src/backend/ref/dh-newhope.c
+++ b/src/backend/ref/dh-newhope.c
@@ -20,8 +20,8 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "internal.h"
-#include "crypto/newhope/newhope.h"
+#include <protocol/internal.h>
+#include <crypto/newhope/newhope.c>
 #include <string.h>
 
 #define MAX_OF(a, b) ((a) > (b) ? (a) : (b))

--- a/src/backend/ref/hash-blake2b.c
+++ b/src/backend/ref/hash-blake2b.c
@@ -20,8 +20,8 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "internal.h"
-#include "crypto/blake2/blake2b.h"
+#include <protocol/internal.h>
+#include <crypto/blake2/blake2b.c>
 
 typedef struct
 {

--- a/src/backend/ref/hash-blake2s.c
+++ b/src/backend/ref/hash-blake2s.c
@@ -20,8 +20,8 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "internal.h"
-#include "crypto/blake2/blake2s.h"
+#include <protocol/internal.h>
+#include <crypto/blake2/blake2s.c>
 
 typedef struct
 {

--- a/src/backend/ref/hash-sha256.c
+++ b/src/backend/ref/hash-sha256.c
@@ -20,8 +20,8 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "internal.h"
-#include "crypto/sha2/sha256.h"
+#include <protocol/internal.h>
+#include <crypto/sha2/sha256.c>
 
 typedef struct
 {

--- a/src/backend/ref/hash-sha512.c
+++ b/src/backend/ref/hash-sha512.c
@@ -20,8 +20,8 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "internal.h"
-#include "crypto/sha2/sha512.h"
+#include <protocol/internal.h>
+#include <crypto/sha2/sha512.c>
 
 typedef struct
 {

--- a/src/backend/ref/sign-ed25519.c
+++ b/src/backend/ref/sign-ed25519.c
@@ -20,8 +20,8 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "internal.h"
-#include "crypto/ed25519/ed25519.h"
+#include "protocol/internal.h"
+#include "crypto/ed25519/ed25519.c"
 
 typedef struct
 {

--- a/src/backend/sodium/cipher-aesgcm.c
+++ b/src/backend/sodium/cipher-aesgcm.c
@@ -21,7 +21,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "internal.h"
+#include <protocol/internal.h>
 #include <sodium.h>
 #include <string.h>
 

--- a/src/backend/sodium/cipher-chachapoly.c
+++ b/src/backend/sodium/cipher-chachapoly.c
@@ -21,7 +21,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "internal.h"
+#include <protocol/internal.h>
 #include <sodium.h>
 #include <string.h>
 

--- a/src/backend/sodium/dh-curve25519.c
+++ b/src/backend/sodium/dh-curve25519.c
@@ -21,7 +21,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "internal.h"
+#include <protocol/internal.h>
 #include <sodium.h>
 #include <string.h>
 

--- a/src/backend/sodium/hash-blake2b.c
+++ b/src/backend/sodium/hash-blake2b.c
@@ -21,7 +21,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "internal.h"
+#include <protocol/internal.h>
 #include <sodium.h>
 
 typedef struct

--- a/src/backend/sodium/hash-sha256.c
+++ b/src/backend/sodium/hash-sha256.c
@@ -21,7 +21,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "internal.h"
+#include <protocol/internal.h>
 #include <sodium.h>
 
 typedef struct

--- a/src/backend/sodium/hash-sha512.c
+++ b/src/backend/sodium/hash-sha512.c
@@ -21,7 +21,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "internal.h"
+#include <protocol/internal.h>
 #include <sodium.h>
 
 typedef struct

--- a/src/backend/sodium/sign-ed25519.c
+++ b/src/backend/sodium/sign-ed25519.c
@@ -21,7 +21,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "internal.h"
+#include <protocol/internal.h>
 #include <sodium.h>
 
 typedef struct


### PR DESCRIPTION
`internal.h` was not correct, `protocol/internal.h` was the correct path, also converted from `"..."` to `<...>`.
`warning: unresolved symbol` fixed by including `*.c` files in some cases instead of `*.h` files.

Fixes #18