### PR TITLE
Only increment nonce on successful decryption

### DIFF
--- a/src/protocol/cipherstate.c
+++ b/src/protocol/cipherstate.c
@@ -399,9 +399,10 @@ int noise_cipherstate_decrypt_with_ad
     /* Decrypt the ciphertext and check the MAC */
     err = (*(state->decrypt))
         (state, ad, ad_len, buffer->data, buffer->size - state->mac_len);
-    ++(state->n);
     if (err != NOISE_ERROR_NONE)
         return err;
+
+    ++(state->n);
 
     /* Adjust the output length for the MAC and return */
     buffer->size -= state->mac_len;

--- a/tests/unit/test-cipherstate.c
+++ b/tests/unit/test-cipherstate.c
@@ -167,7 +167,8 @@ static void check_cipher(int id, size_t key_len, size_t mac_len,
             NOISE_ERROR_MAC_FAILURE);   /* MAC will fail, but that's OK */
     noise_buffer_set_input(mbuf, buffer, pt_len + mac_len);
     compare(noise_cipherstate_decrypt_with_ad(state, a, ad_len, &mbuf),
-            NOISE_ERROR_INVALID_NONCE);
+            NOISE_ERROR_MAC_FAILURE);   /* MAC will fail again, nonce is not
+                                          incremented on failed decryption */
 
     /* Reset the key to clear the "invalid nonce" state */
     compare(noise_cipherstate_init_key(state, k, key_len), NOISE_ERROR_NONE);


### PR DESCRIPTION
As per spec:
> DecryptWithAd(ad, ciphertext): If k is non-empty returns DECRYPT(k, n++, ad, ciphertext). Otherwise returns ciphertext. If an authentication failure occurs in DECRYPT() then n is not incremented and an error is signaled to the caller.

In current implementation nonce is incremented independently from decryption result, which is incorrect.