### PR TITLE
Enable building with libsodium only

### DIFF
--- a/src/protocol/Makefile.am
+++ b/src/protocol/Makefile.am
@@ -69,7 +69,8 @@ libnoiseprotocol_a_SOURCES += \
 else !USE_OPENSSL
 if USE_LIBSODIUM
 libnoiseprotocol_a_SOURCES += \
-	../backend/sodium/cipher-aesgcm.c
+	../backend/sodium/cipher-aesgcm.c \
+	../backend/ref/cipher-aesgcm.c
 else
 libnoiseprotocol_a_SOURCES += \
 	../backend/ref/cipher-aesgcm.c
@@ -79,6 +80,7 @@ endif
 if USE_LIBSODIUM
 libnoiseprotocol_a_SOURCES += \
 	rand_sodium.c \
+	../crypto/ghash/ghash.c \
 	../backend/sodium/cipher-aesgcm.c \
 	../backend/sodium/cipher-chachapoly.c \
 	../backend/sodium/dh-curve25519.c \


### PR DESCRIPTION
We tried to use noise-c only with libsodium support but without openssl support. For us this didn't work, most likely because if openssl is not used libsodium might still need report at runtime that AES GCM support is not available (probably due to build flags of libsodium) so noise-c falls back to the reference implementation (and rightly so). But in the build configuration this was nit reflected as the static library archive was missing the object files for the reference AES GCM implementation.
This PR includes these files and seems to work well.