### PR TITLE
Make ar configurable so cross compiling works

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,7 @@ AC_PROG_CC_STDC
 AC_PROG_RANLIB
 AC_PROG_LEX
 AC_PROG_YACC
+AM_PROG_AR
 AC_PATH_PROG(DOXYGEN, doxygen)
 
 dnl Determine the default Ed448-Goldilocks architecture to use.


### PR DESCRIPTION
This PR adds a configure macro to make the ar command configurable. This is necessary for successful cross compiling builds. noise-c already provided most of the work necessary to create cross compilable builds, only being able to set this tool was missing.