### PR TITLE
Fix use of libsodium for AES.

### DIFF
--- a/src/protocol/Makefile.am
+++ b/src/protocol/Makefile.am
@@ -69,7 +69,8 @@ libnoiseprotocol_a_SOURCES += \
 else !USE_OPENSSL
 if USE_LIBSODIUM
 libnoiseprotocol_a_SOURCES += \
-	../backend/sodium/cipher-aesgcm.c
+	../backend/sodium/cipher-aesgcm.c \
+	../backend/ref/cipher-aesgcm.c
 else
 libnoiseprotocol_a_SOURCES += \
 	../backend/ref/cipher-aesgcm.c
@@ -85,7 +86,9 @@ libnoiseprotocol_a_SOURCES += \
 	../backend/sodium/hash-blake2b.c \
 	../backend/sodium/hash-sha256.c \
 	../backend/sodium/hash-sha512.c \
-	../backend/sodium/sign-ed25519.c
+	../backend/sodium/sign-ed25519.c \
+	../crypto/aes/rijndael-alg-fst.c \
+	../crypto/ghash/ghash.c
 else !USE_LIBSODIUM
 libnoiseprotocol_a_SOURCES += \
 	rand_os.c \

--- a/src/protocol/internal.c
+++ b/src/protocol/internal.c
@@ -23,7 +23,7 @@
 
 #include "internal.h"
 
-#if USE_SODIUM
+#if USE_LIBSODIUM
 NoiseCipherState *noise_aesgcm_new_sodium(void);
 #endif
 #if USE_OPENSSL
@@ -40,7 +40,7 @@ NoiseCipherState *noise_aesgcm_new_ref(void);
 NoiseCipherState *noise_aesgcm_new(void)
 {
     NoiseCipherState *state = 0;
-#if USE_SODIUM
+#if USE_LIBSODIUM
     if (crypto_aead_aes256gcm_is_available())
         state = noise_aesgcm_new_sodium();
 #endif


### PR DESCRIPTION
`src/protocol/internal.c` allows AES to fall back to the ref backend when libsodium reports that `crypto_aead_aes256gcm_is_available` is not available.  However, `Makefile.am` does not then compile in the backend ref for use as a fallback.  Also, `src/protocol/internal.c` mistakenly checks the `USE_SODIUM` definition, while compilation sets the `USE_LIBSODIUM` definition.