### PR TITLE
the keys.h file wasn't being copied into /usr/local/include/noise

### DIFF
--- a/include/noise/Makefile.am
+++ b/include/noise/Makefile.am
@@ -1,6 +1,7 @@
 
 noiseincludedir = $(includedir)/noise
 noiseinclude_HEADERS = \
+    keys.h \
     protocol.h \
     protobufs.h
 


### PR DESCRIPTION
this seems like a simple oversight in the `Makefile.am`; the other `.h` files are listed there, but `keys.h` is missing.  

(Thanks for putting up with my premature PRs about this earlier today -- I hadn't fully verified the fix and thought I was PR merging to master of my fork, not your master.)